### PR TITLE
Remove unused _rgb_to_hs_brightness method

### DIFF
--- a/custom_components/color_notify/light.py
+++ b/custom_components/color_notify/light.py
@@ -745,16 +745,6 @@ class NotificationLightEntity(LightEntity, RestoreEntity):
         )
         return True
 
-    @staticmethod
-    def _rgb_to_hs_brightness(
-        r: float, g: float, b: float
-    ) -> tuple[float, float, float]:
-        """Return RGB to HS plus brightness."""
-        h, s, v = color_RGB_to_hsv(r, g, b)
-        # Re-scale 'v' from 0-100 to 0-255
-        v = round((255 / 100) * v)
-        return (h, s, v)
-
     def _create_sequence_from_attr(
         self, attributes: dict[str, Any], notify_id: str | None = None
     ) -> _NotificationSequence:


### PR DESCRIPTION
## Summary

- Remove `_rgb_to_hs_brightness` static method (zero callers)
- The equivalent logic is already inlined at lines 726-731 (`color_RGB_to_hsv` + brightness rescale)

## Test plan

- [x] Grep confirms no callers in the codebase