### PR TITLE
Fix worker loop race: move spawn to end of async_added_to_hass

### DIFF
--- a/custom_components/color_notify/light.py
+++ b/custom_components/color_notify/light.py
@@ -263,11 +263,6 @@ class NotificationLightEntity(LightEntity, RestoreEntity):
         # Add the 'OFF' sequence so the list isn't empty
         self._active_sequences[STATE_OFF] = LIGHT_OFF_SEQUENCE
 
-        # Spawn the worker function background task to manage this bulb
-        self._task = self._config_entry.async_create_background_task(
-            self.hass, self._worker_func(), name=f"{self.name} background task"
-        )
-
         # Check if the wrapped entity is valid at startup
         state = self.hass.states.get(self._wrapped_entity_id)
         if state:
@@ -352,6 +347,12 @@ class NotificationLightEntity(LightEntity, RestoreEntity):
                 self.hass.async_create_task(self.async_turn_on())
             else:
                 self.hass.async_create_task(self.async_turn_off())
+
+        # Spawn the worker function background task to manage this bulb.
+        # This must happen after state restore to avoid racing with initialization.
+        self._task = self._config_entry.async_create_background_task(
+            self.hass, self._worker_func(), name=f"{self.name} background task"
+        )
 
     async def async_will_remove_from_hass(self):
         """Clean up before removal from HASS."""

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+asyncio_mode = auto

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,88 @@
+"""Stub homeassistant modules for unit testing without full HA install."""
+
+import sys
+import types
+from unittest.mock import MagicMock
+
+# Stub out homeassistant modules before any imports
+HA_MODULES = [
+    "homeassistant",
+    "homeassistant.components",
+    "homeassistant.components.light",
+    "homeassistant.components.switch",
+    "homeassistant.config_entries",
+    "homeassistant.const",
+    "homeassistant.core",
+    "homeassistant.helpers",
+    "homeassistant.helpers.config_validation",
+    "homeassistant.helpers.entity",
+    "homeassistant.helpers.entity_platform",
+    "homeassistant.helpers.entity_registry",
+    "homeassistant.helpers.event",
+    "homeassistant.helpers.restore_state",
+    "homeassistant.helpers.selector",
+    "homeassistant.util",
+    "homeassistant.util.color",
+    "voluptuous",
+]
+
+for mod_name in HA_MODULES:
+    if mod_name not in sys.modules:
+        sys.modules[mod_name] = MagicMock()
+
+# Set specific constants that our code imports
+ha_const = sys.modules["homeassistant.const"]
+ha_const.ATTR_ENTITY_ID = "entity_id"
+ha_const.CONF_DELAY = "delay"
+ha_const.CONF_DELAY_TIME = "delay_time"
+ha_const.CONF_ENTITIES = "entities"
+ha_const.CONF_ENTITY_ID = "entity_id"
+ha_const.CONF_FORCE_UPDATE = "force_update"
+ha_const.CONF_NAME = "name"
+ha_const.CONF_TYPE = "type"
+ha_const.CONF_UNIQUE_ID = "unique_id"
+ha_const.SERVICE_TURN_OFF = "turn_off"
+ha_const.SERVICE_TURN_ON = "turn_on"
+ha_const.STATE_OFF = "off"
+ha_const.STATE_ON = "on"
+ha_const.Platform = MagicMock()
+
+ha_light = sys.modules["homeassistant.components.light"]
+ha_light.ATTR_BRIGHTNESS = "brightness"
+ha_light.ATTR_COLOR_MODE = "color_mode"
+ha_light.ATTR_COLOR_TEMP_KELVIN = "color_temp_kelvin"
+ha_light.ATTR_HS_COLOR = "hs_color"
+ha_light.ATTR_RGB_COLOR = "rgb_color"
+ha_light.ATTR_XY_COLOR = "xy_color"
+ha_light.ColorMode = MagicMock()
+ha_light.ColorMode.COLOR_TEMP = "color_temp"
+class _StubLightEntity:
+    _attr_is_on = None
+    _attr_name = None
+    entity_id = None
+
+    @property
+    def is_on(self):
+        return self._attr_is_on
+
+    @property
+    def name(self):
+        return self._attr_name
+
+    async def async_added_to_hass(self):
+        pass
+
+ha_light.LightEntity = _StubLightEntity
+ha_light.DOMAIN = "light"
+
+ha_switch = sys.modules["homeassistant.components.switch"]
+ha_switch.DOMAIN = "switch"
+
+ha_restore = sys.modules["homeassistant.helpers.restore_state"]
+ha_restore.RestoreEntity = type("RestoreEntity", (), {})
+
+ha_core = sys.modules["homeassistant.core"]
+ha_core.callback = lambda f: f
+ha_core.Event = MagicMock()
+ha_core.EventStateChangedData = MagicMock()
+ha_core.HomeAssistant = MagicMock()

--- a/tests/test_light.py
+++ b/tests/test_light.py
@@ -1,0 +1,73 @@
+"""Tests for worker task spawn ordering in async_added_to_hass."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+from custom_components.color_notify.light import NotificationLightEntity
+
+
+class FakeState:
+    def __init__(self, state: str):
+        self.state = state
+
+
+def make_entity():
+    entry = MagicMock()
+    entry.data = {
+        "type": "light",
+        "name": "Test Light",
+        "entity_id": "light.test",
+        "color_picker": [255, 249, 216],
+        "dynamic_priority": True,
+        "priority": 1000,
+        "delay": True,
+        "delay_time": {"seconds": 5},
+        "peek_time": {"seconds": 5},
+    }
+    entry.options = {}
+    entry.title = "[Light] Test Light"
+    entry.async_create_background_task = MagicMock()
+    entry.async_on_unload = MagicMock()
+
+    entity = NotificationLightEntity(
+        unique_id="test_id",
+        wrapped_entity_id="light.test",
+        config_entry=entry,
+    )
+    entity.hass = MagicMock()
+    entity.hass.states.get.return_value = None
+    entity.async_write_ha_state = MagicMock()
+    entity.async_schedule_update_ha_state = MagicMock()
+
+    return entity, entry
+
+
+class TestWorkerSpawnOrder:
+    """Worker task spawns after state restore in async_added_to_hass."""
+
+    async def test_worker_spawns_after_state_restore(self):
+        """Background task is created after async_get_last_state completes."""
+        entity, entry = make_entity()
+        call_order = []
+
+        async def tracked_get_last_state():
+            call_order.append("get_last_state")
+            return FakeState("on")
+
+        def tracked_create_background_task(*args, **kwargs):
+            call_order.append("create_background_task")
+
+        entity.async_get_last_state = tracked_get_last_state
+        entry.async_create_background_task = tracked_create_background_task
+
+        await entity.async_added_to_hass()
+
+        assert call_order.index("create_background_task") > call_order.index("get_last_state")
+
+    async def test_worker_spawns_without_restored_state(self):
+        """Background task is created even when there's no restored state."""
+        entity, entry = make_entity()
+        entity.async_get_last_state = AsyncMock(return_value=None)
+
+        await entity.async_added_to_hass()
+
+        entry.async_create_background_task.assert_called_once()


### PR DESCRIPTION
## Summary

- Move worker task spawn to end of `async_added_to_hass`, after state restore completes
- Prevents race where worker loop processes queue items before initialization finishes
- This is the approach you suggested in PR #4 feedback

## Test plan

- [x] Unit test verifies `create_background_task` is called after `async_get_last_state`
- [x] Unit test verifies worker spawns even when no restored state exists
- [x] `pytest` passes (2 tests)