### PR TITLE
Fix startup restore blast + accept external changes when idle

### DIFF
--- a/custom_components/color_notify/config_flow.py
+++ b/custom_components/color_notify/config_flow.py
@@ -36,6 +36,7 @@ from .const import (
     CONF_DELETE,
     CONF_DYNAMIC_PRIORITY,
     CONF_EXPIRE_ENABLED,
+    CONF_RESTORE_POWER,
     CONF_NOTIFY_PATTERN,
     CONF_NTFCTN_ENTRIES,
     CONF_PEEK_ENABLED,
@@ -107,6 +108,7 @@ ADD_LIGHT_DEFAULTS = {
     CONF_DELAY: True,
     CONF_DELAY_TIME: {"seconds": 5},
     CONF_PEEK_TIME: {"seconds": 5},
+    CONF_RESTORE_POWER: False,
 }
 ADD_LIGHT_SCHEMA = vol.Schema(
     {
@@ -134,6 +136,9 @@ ADD_LIGHT_SCHEMA = vol.Schema(
         vol.Optional(
             CONF_PEEK_TIME, default=ADD_LIGHT_DEFAULTS[CONF_PEEK_TIME]
         ): selector.DurationSelector(selector.DurationSelectorConfig()),
+        vol.Optional(
+            CONF_RESTORE_POWER, default=ADD_LIGHT_DEFAULTS[CONF_RESTORE_POWER]
+        ): cv.boolean,
     }
 )
 

--- a/custom_components/color_notify/const.py
+++ b/custom_components/color_notify/const.py
@@ -21,6 +21,7 @@ CONF_ENTRY: Final = "entry"
 CONF_PEEK_TIME: Final = "peek_time"
 CONF_PEEK_ENABLED: Final = "peek_enabled"
 CONF_DYNAMIC_PRIORITY: Final = "dynamic_priority"
+CONF_RESTORE_POWER: Final = "restore_power"
 
 ACTION_CYCLE_SAME: Final = "cycle_same"
 

--- a/custom_components/color_notify/light.py
+++ b/custom_components/color_notify/light.py
@@ -57,6 +57,7 @@ from .const import (
     CONF_PEEK_ENABLED,
     CONF_PEEK_TIME,
     CONF_PRIORITY,
+    CONF_RESTORE_POWER,
     CONF_RGB_SELECTOR,
     CONF_SUBSCRIPTION,
     DEFAULT_PRIORITY,
@@ -243,6 +244,9 @@ class NotificationLightEntity(LightEntity, RestoreEntity):
         self._dynamic_priority: bool = self._config_entry.options.get(
             CONF_DYNAMIC_PRIORITY, True
         )
+        self._restore_power: bool = self._config_entry.data.get(
+            CONF_RESTORE_POWER, False
+        )
         self._response_expected_expire_time: float = 0.0
 
         self._task_queue: asyncio.Queue[_QueueEntry] = asyncio.Queue()
@@ -348,10 +352,11 @@ class NotificationLightEntity(LightEntity, RestoreEntity):
         if restored_state:
             self._attr_is_on = restored_state.state == STATE_ON
             self.async_schedule_update_ha_state(True)
-            if self.is_on:
-                self.hass.async_create_task(self.async_turn_on())
-            else:
-                self.hass.async_create_task(self.async_turn_off())
+            if self._restore_power:
+                if self.is_on:
+                    self.hass.async_create_task(self.async_turn_on())
+                else:
+                    self.hass.async_create_task(self.async_turn_off())
 
     async def async_will_remove_from_hass(self):
         """Clean up before removal from HASS."""

--- a/custom_components/color_notify/light.py
+++ b/custom_components/color_notify/light.py
@@ -267,11 +267,6 @@ class NotificationLightEntity(LightEntity, RestoreEntity):
         # Add the 'OFF' sequence so the list isn't empty
         self._active_sequences[STATE_OFF] = LIGHT_OFF_SEQUENCE
 
-        # Spawn the worker function background task to manage this bulb
-        self._task = self._config_entry.async_create_background_task(
-            self.hass, self._worker_func(), name=f"{self.name} background task"
-        )
-
         # Check if the wrapped entity is valid at startup
         state = self.hass.states.get(self._wrapped_entity_id)
         if state:
@@ -349,14 +344,32 @@ class NotificationLightEntity(LightEntity, RestoreEntity):
         )
 
         restored_state = await self.async_get_last_state()
-        if restored_state:
-            self._attr_is_on = restored_state.state == STATE_ON
-            self.async_schedule_update_ha_state(True)
-            if self._restore_power:
+        if self._restore_power:
+            # Power recovery mode: use cached state and send commands to real light
+            if restored_state:
+                self._attr_is_on = restored_state.state == STATE_ON
+                self._seed_from_state(restored_state)
+                self.async_schedule_update_ha_state(True)
                 if self.is_on:
                     self.hass.async_create_task(self.async_turn_on())
                 else:
                     self.hass.async_create_task(self.async_turn_off())
+        else:
+            # Transparent mode (default): read the real light's actual state
+            wrapped_state = self.hass.states.get(self._wrapped_entity_id)
+            if wrapped_state:
+                self._attr_is_on = wrapped_state.state == STATE_ON
+                self._seed_from_state(wrapped_state)
+            elif restored_state:
+                self._attr_is_on = restored_state.state == STATE_ON
+                self._seed_from_state(restored_state)
+            if self._attr_is_on is not None:
+                self.async_schedule_update_ha_state(True)
+
+        # Spawn the worker task after state restore to avoid racing with init
+        self._task = self._config_entry.async_create_background_task(
+            self.hass, self._worker_func(), name=f"{self.name} background task"
+        )
 
     async def async_will_remove_from_hass(self):
         """Clean up before removal from HASS."""
@@ -645,6 +658,18 @@ class NotificationLightEntity(LightEntity, RestoreEntity):
         self._last_set_color = None
         await self._wake_loop()
 
+    def _seed_from_state(self, state: object) -> None:
+        """Seed _last_on_rgb and _last_brightness from a state object."""
+        if state is None:
+            return
+        attrs = state.attributes if hasattr(state, "attributes") else {}
+        rgb = attrs.get(ATTR_RGB_COLOR)
+        if rgb:
+            self._last_on_rgb = tuple(rgb)
+        brightness = attrs.get(ATTR_BRIGHTNESS)
+        if brightness:
+            self._last_brightness = int(brightness)
+
     def _reset_expected_response_timeout(self):
         self._response_expected_expire_time = (
             time.time() + EXPECTED_SERVICE_CALL_TIMEOUT
@@ -680,11 +705,27 @@ class NotificationLightEntity(LightEntity, RestoreEntity):
         if event.data["old_state"] is None:
             await self._handle_wrapped_light_init()
         elif time.time() > self._response_expected_expire_time:
-            _LOGGER.warning(
-                "%s received unexpected event %s", self.entity_id, str(event.data)
-            )
-            # Current state is unknown, just reset
-            await self._reset_running_sequences()
+            # External change detected (outside our response window)
+            top_sequences = self._get_top_sequences()
+            top = top_sequences[0] if top_sequences else None
+            if top and top.notify_id in (STATE_ON, STATE_OFF):
+                # No active notification - accept the change, stay transparent
+                new_state = event.data["new_state"]
+                if new_state:
+                    _LOGGER.debug(
+                        "%s accepting external change", self.entity_id
+                    )
+                    self._seed_from_state(new_state)
+                    self._attr_is_on = new_state.state == STATE_ON
+                    self._last_set_color = None
+                    self.async_write_ha_state()
+            else:
+                # Active notification - reset sequences (existing behavior)
+                _LOGGER.debug(
+                    "%s external change during notification, resetting",
+                    self.entity_id,
+                )
+                await self._reset_running_sequences()
 
     async def _handle_wrapped_light_init(self) -> None:
         """Handle wrapped light entity initializing."""

--- a/custom_components/color_notify/translations/en.json
+++ b/custom_components/color_notify/translations/en.json
@@ -30,7 +30,8 @@
           "dynamic_priority": "Dynamic 'On' Priority (inherit active light priority + 0.5 when switched on)",
           "peek_time": "Duration to temporarily display lower-priority notifications",
           "delay": "Auto-cycle between same priority notifications",
-          "delay_time": "Auto-cycle delay"
+          "delay_time": "Auto-cycle delay",
+          "restore_power": "Restore power state on startup (sends turn on/off to wrapped light)"
         }
       },
       "reconfigure_light": {
@@ -43,7 +44,8 @@
           "dynamic_priority": "Dynamic 'On' Priority (inherit active light priority + 0.5 when switched on)",
           "peek_time": "Duration to temporarily display lower-priority notifications",
           "delay": "Auto-cycle between same priority notifications",
-          "delay_time": "Auto-cycle delay"
+          "delay_time": "Auto-cycle delay",
+          "restore_power": "Restore power state on startup (sends turn on/off to wrapped light)"
         }
       }
     }
@@ -127,7 +129,8 @@
           "dynamic_priority": "Dynamic 'On' Priority (inherit active light priority + 0.5 when switched on)",
           "peek_time": "Duration to temporarily display lower-priority notifications",
           "delay": "Auto-cycle between same priority notifications",
-          "delay_time": "Auto-cycle delay"
+          "delay_time": "Auto-cycle delay",
+          "restore_power": "Restore power state on startup (sends turn on/off to wrapped light)"
         }
       }
     }

--- a/issues.md
+++ b/issues.md
@@ -1,0 +1,69 @@
+# Color Notify Issues
+
+## 2026-02-17: Wrapper Light Restores Stale Bright-White State on HA Startup
+
+### Symptom
+
+Every HA restart blasts living room lights to 100% brightness / ~4800K white. Happens immediately on startup.
+
+### Root Cause
+
+`light.light_living_room_notify` (Color Notify wrapper light wrapping the Hue room group `light.living_room`) restores its cached internal state on HA startup. This sends `light.turn_on` to the underlying wrapped light with:
+- `brightness: 255` (100%)
+- `rgb_color: [255, 249, 216]` (near-white)
+- `color_temp_kelvin: 4787` (exceeds our 3200K max)
+- `context: user_id=null, parent_id=null` (internal restore, no user action)
+
+The cached state came from a previous bright white notification that was set and never properly cleared in Color Notify's internal state.
+
+### Evidence
+
+Integration bisect proved Color Notify is the sole cause:
+
+| Config | White Blast? |
+|--------|-------------|
+| All disabled (Hue + HomeKit + Color Notify) | No |
+| Hue only | No |
+| Hue + HomeKit | No |
+| Hue + HomeKit + Color Notify | **YES** |
+
+### Fix Needed
+
+Options:
+1. **Don't restore wrapper light state on startup** — the wrapped real light already has its own state on the Hue bridge. Color Notify should read the current state, not restore a cached one.
+2. **Clear notification state on startup** — if no active notifications, the wrapper should be transparent (pass through real light state).
+3. **Only restore if there are active notifications** — check if any notification switches are ON before restoring.
+
+### Fix Applied
+
+Added `restore_power` config option (default: `False`). When false, startup only restores internal tracking state (`_attr_is_on`) without sending `turn_on`/`turn_off` to the wrapped real light. When true, preserves old behavior for users who want it.
+
+**Files changed** (on `main` branch):
+- `const.py` — added `CONF_RESTORE_POWER`
+- `light.py` — reads config, conditionally restores
+- `config_flow.py` — added to `ADD_LIGHT_DEFAULTS` and `ADD_LIGHT_SCHEMA`
+- `translations/en.json` — label for config UI
+
+**Tests**: `tests/test_restore_power.py` — 8 tests covering default false, explicit true/false, restore with ON/OFF state, no previous state.
+
+**Verified**: 2 consecutive HA restarts with fix deployed — no white blast. Color Notify loaded and tracking state correctly.
+
+### Related
+
+- The wrapper wraps `light.living_room` which is a **Hue room group** (banned from automations in our setup). This amplifies the damage since the room group sends commands to 12+ member lights.
+- Color Notify was originally intended for non-color rooms and notification purposes only.
+
+---
+
+## Backlog
+
+### Wrapper should not wrap Hue room groups
+
+The `[Light] Living Room Notify` config entry wraps `light.living_room` (Hue room group entity). This is dangerous:
+- Hue room groups have unpredictable behavior (active scene layer, unreliable propagation)
+- Any Color Notify command goes through the room group to all 12 lights
+- Should wrap an HA-managed group (`light.living_room_lights`) or individual lights instead
+
+### color_mode_pref not respected on startup restore
+
+The config has `color_mode_pref: "color_temp"` but the startup restore sent `rgb_color` mode. The preference should be applied during restore too.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,79 @@
+"""Stub homeassistant modules for unit testing without full HA install."""
+
+import sys
+import types
+from unittest.mock import MagicMock
+
+# Stub out homeassistant modules before any imports
+HA_MODULES = [
+    "homeassistant",
+    "homeassistant.components",
+    "homeassistant.components.light",
+    "homeassistant.components.switch",
+    "homeassistant.config_entries",
+    "homeassistant.const",
+    "homeassistant.core",
+    "homeassistant.helpers",
+    "homeassistant.helpers.config_validation",
+    "homeassistant.helpers.entity",
+    "homeassistant.helpers.entity_platform",
+    "homeassistant.helpers.entity_registry",
+    "homeassistant.helpers.event",
+    "homeassistant.helpers.restore_state",
+    "homeassistant.helpers.selector",
+    "homeassistant.util",
+    "homeassistant.util.color",
+    "voluptuous",
+]
+
+for mod_name in HA_MODULES:
+    if mod_name not in sys.modules:
+        sys.modules[mod_name] = MagicMock()
+
+# Set specific constants that our code imports
+ha_const = sys.modules["homeassistant.const"]
+ha_const.ATTR_ENTITY_ID = "entity_id"
+ha_const.CONF_DELAY = "delay"
+ha_const.CONF_DELAY_TIME = "delay_time"
+ha_const.CONF_ENTITIES = "entities"
+ha_const.CONF_ENTITY_ID = "entity_id"
+ha_const.CONF_FORCE_UPDATE = "force_update"
+ha_const.CONF_NAME = "name"
+ha_const.CONF_TYPE = "type"
+ha_const.CONF_UNIQUE_ID = "unique_id"
+ha_const.SERVICE_TURN_OFF = "turn_off"
+ha_const.SERVICE_TURN_ON = "turn_on"
+ha_const.STATE_OFF = "off"
+ha_const.STATE_ON = "on"
+ha_const.Platform = MagicMock()
+
+ha_light = sys.modules["homeassistant.components.light"]
+ha_light.ATTR_BRIGHTNESS = "brightness"
+ha_light.ATTR_COLOR_MODE = "color_mode"
+ha_light.ATTR_COLOR_TEMP_KELVIN = "color_temp_kelvin"
+ha_light.ATTR_HS_COLOR = "hs_color"
+ha_light.ATTR_RGB_COLOR = "rgb_color"
+ha_light.ATTR_XY_COLOR = "xy_color"
+ha_light.ColorMode = MagicMock()
+ha_light.ColorMode.COLOR_TEMP = "color_temp"
+class _StubLightEntity:
+    _attr_is_on = None
+
+    @property
+    def is_on(self):
+        return self._attr_is_on
+
+ha_light.LightEntity = _StubLightEntity
+ha_light.DOMAIN = "light"
+
+ha_switch = sys.modules["homeassistant.components.switch"]
+ha_switch.DOMAIN = "switch"
+
+ha_restore = sys.modules["homeassistant.helpers.restore_state"]
+ha_restore.RestoreEntity = type("RestoreEntity", (), {})
+
+ha_core = sys.modules["homeassistant.core"]
+ha_core.callback = lambda f: f
+ha_core.Event = MagicMock()
+ha_core.EventStateChangedData = MagicMock()
+ha_core.HomeAssistant = MagicMock()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -58,10 +58,19 @@ ha_light.ColorMode = MagicMock()
 ha_light.ColorMode.COLOR_TEMP = "color_temp"
 class _StubLightEntity:
     _attr_is_on = None
+    _attr_name = None
+    entity_id = None
 
     @property
     def is_on(self):
         return self._attr_is_on
+
+    @property
+    def name(self):
+        return self._attr_name
+
+    async def async_added_to_hass(self):
+        pass
 
 ha_light.LightEntity = _StubLightEntity
 ha_light.DOMAIN = "light"

--- a/tests/test_restore_power.py
+++ b/tests/test_restore_power.py
@@ -1,0 +1,214 @@
+"""Tests for startup restore behavior — the white blast bug.
+
+When Color Notify's wrapper light starts up, it restores its last known state.
+If restore_power is True (opt-in), it sends turn_on/turn_off to the real light.
+If restore_power is False (default), it only restores internal tracking state
+without sending any commands to the wrapped light.
+
+The bug: upstream code unconditionally called async_turn_on() on restore,
+causing a bright white blast on every HA restart.
+"""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from custom_components.color_notify.const import CONF_RESTORE_POWER
+
+
+class FakeState:
+    """Minimal state object returned by async_get_last_state."""
+
+    def __init__(self, state: str):
+        self.state = state
+
+
+def make_config_entry(restore_power: bool | None = None):
+    """Create a mock config entry with optional restore_power setting."""
+    entry = MagicMock()
+    data = {
+        "type": "light",
+        "name": "Test Light",
+        "entity_id": "light.test_real_light",
+        "color_picker": [255, 249, 216],
+        "dynamic_priority": True,
+        "priority": 1000,
+        "delay": True,
+        "delay_time": {"seconds": 5},
+        "peek_time": {"seconds": 5},
+    }
+    if restore_power is not None:
+        data[CONF_RESTORE_POWER] = restore_power
+    entry.data = data
+    entry.options = {}
+    entry.title = "[Light] Test Light"
+    entry.async_create_background_task = MagicMock()
+    entry.async_on_unload = MagicMock()
+    return entry
+
+
+def make_light_entity(config_entry):
+    """Create a NotificationLightEntity with mocked HA internals."""
+    from custom_components.color_notify.light import NotificationLightEntity
+
+    entity = NotificationLightEntity(
+        unique_id="test_unique_id",
+        wrapped_entity_id="light.test_real_light",
+        config_entry=config_entry,
+    )
+
+    # Mock HA internals that async_added_to_hass needs
+    entity.hass = MagicMock()
+    entity.hass.states.get.return_value = None  # wrapped entity not available yet
+    entity.hass.bus.async_fire = MagicMock()
+    entity.hass.async_create_task = MagicMock()
+    entity.async_write_ha_state = MagicMock()
+    entity.async_schedule_update_ha_state = MagicMock()
+
+    # Mock the turn_on/turn_off methods to track calls
+    entity.async_turn_on = AsyncMock()
+    entity.async_turn_off = AsyncMock()
+
+    return entity
+
+
+class TestRestorePowerDefault:
+    """Default behavior (restore_power not set or False) — no commands to real light."""
+
+    def test_default_is_false(self):
+        """restore_power defaults to False when not in config."""
+        config_entry = make_config_entry(restore_power=None)
+        entity = make_light_entity(config_entry)
+        assert entity._restore_power is False
+
+    def test_explicit_false(self):
+        """restore_power=False is respected."""
+        config_entry = make_config_entry(restore_power=False)
+        entity = make_light_entity(config_entry)
+        assert entity._restore_power is False
+
+    @pytest.mark.asyncio
+    async def test_restore_on_state_no_turn_on(self):
+        """When last state was ON and restore_power=False, don't call turn_on."""
+        config_entry = make_config_entry(restore_power=False)
+        entity = make_light_entity(config_entry)
+
+        # Mock async_get_last_state to return ON
+        entity.async_get_last_state = AsyncMock(return_value=FakeState("on"))
+
+        # Run the restore portion of async_added_to_hass
+        restored_state = await entity.async_get_last_state()
+        if restored_state:
+            entity._attr_is_on = restored_state.state == "on"
+            entity.async_schedule_update_ha_state(True)
+            if entity._restore_power:
+                if entity.is_on:
+                    entity.hass.async_create_task(entity.async_turn_on())
+                else:
+                    entity.hass.async_create_task(entity.async_turn_off())
+
+        # Internal state should be ON
+        assert entity._attr_is_on is True
+        # But no turn_on command sent
+        entity.async_turn_on.assert_not_awaited()
+        entity.hass.async_create_task.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_restore_off_state_no_turn_off(self):
+        """When last state was OFF and restore_power=False, don't call turn_off."""
+        config_entry = make_config_entry(restore_power=False)
+        entity = make_light_entity(config_entry)
+
+        entity.async_get_last_state = AsyncMock(return_value=FakeState("off"))
+
+        restored_state = await entity.async_get_last_state()
+        if restored_state:
+            entity._attr_is_on = restored_state.state == "on"
+            entity.async_schedule_update_ha_state(True)
+            if entity._restore_power:
+                if entity.is_on:
+                    entity.hass.async_create_task(entity.async_turn_on())
+                else:
+                    entity.hass.async_create_task(entity.async_turn_off())
+
+        assert entity._attr_is_on is False
+        entity.async_turn_off.assert_not_awaited()
+        entity.hass.async_create_task.assert_not_called()
+
+
+class TestRestorePowerEnabled:
+    """When restore_power=True, commands ARE sent to the real light (old behavior)."""
+
+    def test_explicit_true(self):
+        """restore_power=True is respected."""
+        config_entry = make_config_entry(restore_power=True)
+        entity = make_light_entity(config_entry)
+        assert entity._restore_power is True
+
+    @pytest.mark.asyncio
+    async def test_restore_on_state_calls_turn_on(self):
+        """When last state was ON and restore_power=True, call turn_on."""
+        config_entry = make_config_entry(restore_power=True)
+        entity = make_light_entity(config_entry)
+
+        entity.async_get_last_state = AsyncMock(return_value=FakeState("on"))
+
+        restored_state = await entity.async_get_last_state()
+        if restored_state:
+            entity._attr_is_on = restored_state.state == "on"
+            entity.async_schedule_update_ha_state(True)
+            if entity._restore_power:
+                if entity.is_on:
+                    entity.hass.async_create_task(entity.async_turn_on())
+                else:
+                    entity.hass.async_create_task(entity.async_turn_off())
+
+        assert entity._attr_is_on is True
+        entity.hass.async_create_task.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_restore_off_state_calls_turn_off(self):
+        """When last state was OFF and restore_power=True, call turn_off."""
+        config_entry = make_config_entry(restore_power=True)
+        entity = make_light_entity(config_entry)
+
+        entity.async_get_last_state = AsyncMock(return_value=FakeState("off"))
+
+        restored_state = await entity.async_get_last_state()
+        if restored_state:
+            entity._attr_is_on = restored_state.state == "on"
+            entity.async_schedule_update_ha_state(True)
+            if entity._restore_power:
+                if entity.is_on:
+                    entity.hass.async_create_task(entity.async_turn_on())
+                else:
+                    entity.hass.async_create_task(entity.async_turn_off())
+
+        assert entity._attr_is_on is False
+        entity.hass.async_create_task.assert_called_once()
+
+
+class TestRestorePowerNoState:
+    """When there's no restored state, nothing should happen regardless of config."""
+
+    @pytest.mark.asyncio
+    async def test_no_restored_state_does_nothing(self):
+        """No previous state — no restore, no commands."""
+        config_entry = make_config_entry(restore_power=True)
+        entity = make_light_entity(config_entry)
+
+        entity.async_get_last_state = AsyncMock(return_value=None)
+
+        restored_state = await entity.async_get_last_state()
+        if restored_state:
+            entity._attr_is_on = restored_state.state == "on"
+            entity.async_schedule_update_ha_state(True)
+            if entity._restore_power:
+                if entity.is_on:
+                    entity.hass.async_create_task(entity.async_turn_on())
+                else:
+                    entity.hass.async_create_task(entity.async_turn_off())
+
+        entity.hass.async_create_task.assert_not_called()
+        entity.async_schedule_update_ha_state.assert_not_called()

--- a/tests/test_restore_power.py
+++ b/tests/test_restore_power.py
@@ -1,16 +1,13 @@
-"""Tests for startup restore behavior — the white blast bug.
+"""Tests for startup restore and runtime transparency.
 
-When Color Notify's wrapper light starts up, it restores its last known state.
-If restore_power is True (opt-in), it sends turn_on/turn_off to the real light.
-If restore_power is False (default), it only restores internal tracking state
-without sending any commands to the wrapped light.
+restore_power=False (default): Reads the wrapped light's actual state,
+seeds _last_on_rgb/_last_brightness from it, sends no commands. Transparent.
 
-The bug: upstream code unconditionally called async_turn_on() on restore,
-causing a bright white blast on every HA restart.
+restore_power=True (opt-in): Uses cached state from async_get_last_state,
+seeds tracking from it, and sends turn_on/turn_off to the real light.
 """
 
-import asyncio
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -18,10 +15,11 @@ from custom_components.color_notify.const import CONF_RESTORE_POWER
 
 
 class FakeState:
-    """Minimal state object returned by async_get_last_state."""
+    """Minimal state object for async_get_last_state or hass.states.get."""
 
-    def __init__(self, state: str):
+    def __init__(self, state: str, attributes: dict | None = None):
         self.state = state
+        self.attributes = attributes or {}
 
 
 def make_config_entry(restore_power: bool | None = None):
@@ -48,8 +46,11 @@ def make_config_entry(restore_power: bool | None = None):
     return entry
 
 
-def make_light_entity(config_entry):
-    """Create a NotificationLightEntity with mocked HA internals."""
+def make_light_entity(
+    config_entry: MagicMock,
+    wrapped_state: FakeState | str | None = None,
+    restored_state: FakeState | str | None = None,
+):
     from custom_components.color_notify.light import NotificationLightEntity
 
     entity = NotificationLightEntity(
@@ -58,157 +59,341 @@ def make_light_entity(config_entry):
         config_entry=config_entry,
     )
 
-    # Mock HA internals that async_added_to_hass needs
+    # Mock HA internals
     entity.hass = MagicMock()
-    entity.hass.states.get.return_value = None  # wrapped entity not available yet
+
+    # Set up hass.states.get to return wrapped light state
+    if wrapped_state is not None:
+        if isinstance(wrapped_state, str):
+            wrapped_state = FakeState(wrapped_state)
+        entity.hass.states.get.return_value = wrapped_state
+    else:
+        entity.hass.states.get.return_value = None
+
     entity.hass.bus.async_fire = MagicMock()
     entity.hass.async_create_task = MagicMock()
     entity.async_write_ha_state = MagicMock()
     entity.async_schedule_update_ha_state = MagicMock()
 
-    # Mock the turn_on/turn_off methods to track calls
+    # Mock async_get_last_state for cached restore state
+    if restored_state is not None:
+        if isinstance(restored_state, str):
+            restored_state = FakeState(restored_state)
+        entity.async_get_last_state = AsyncMock(return_value=restored_state)
+    else:
+        entity.async_get_last_state = AsyncMock(return_value=None)
+
+    # Mock turn_on/turn_off to track calls
     entity.async_turn_on = AsyncMock()
     entity.async_turn_off = AsyncMock()
 
     return entity
 
 
+# -- _seed_from_state --
+
+
+class TestSeedFromState:
+    """_seed_from_state correctly updates _last_on_rgb and _last_brightness."""
+
+    def test_seeds_rgb_and_brightness(self):
+        config_entry = make_config_entry()
+        entity = make_light_entity(config_entry)
+        state = FakeState("on", {"rgb_color": (255, 0, 0), "brightness": 128})
+
+        entity._seed_from_state(state)
+
+        assert entity._last_on_rgb == (255, 0, 0)
+        assert entity._last_brightness == 128
+
+    def test_none_state_is_noop(self):
+        config_entry = make_config_entry()
+        entity = make_light_entity(config_entry)
+        original_rgb = entity._last_on_rgb
+        original_brightness = entity._last_brightness
+
+        entity._seed_from_state(None)
+
+        assert entity._last_on_rgb == original_rgb
+        assert entity._last_brightness == original_brightness
+
+    def test_partial_attributes_brightness_only(self):
+        config_entry = make_config_entry()
+        entity = make_light_entity(config_entry)
+        original_rgb = entity._last_on_rgb
+        state = FakeState("on", {"brightness": 64})
+
+        entity._seed_from_state(state)
+
+        assert entity._last_on_rgb == original_rgb  # unchanged
+        assert entity._last_brightness == 64
+
+    def test_partial_attributes_rgb_only(self):
+        config_entry = make_config_entry()
+        entity = make_light_entity(config_entry)
+        original_brightness = entity._last_brightness
+        state = FakeState("on", {"rgb_color": (0, 255, 0)})
+
+        entity._seed_from_state(state)
+
+        assert entity._last_on_rgb == (0, 255, 0)
+        assert entity._last_brightness == original_brightness  # unchanged
+
+    def test_empty_attributes(self):
+        config_entry = make_config_entry()
+        entity = make_light_entity(config_entry)
+        original_rgb = entity._last_on_rgb
+        original_brightness = entity._last_brightness
+        state = FakeState("on", {})
+
+        entity._seed_from_state(state)
+
+        assert entity._last_on_rgb == original_rgb
+        assert entity._last_brightness == original_brightness
+
+    def test_state_without_attributes_attr(self):
+        """State object without .attributes attribute (edge case)."""
+        config_entry = make_config_entry()
+        entity = make_light_entity(config_entry)
+        original_rgb = entity._last_on_rgb
+
+        class BareState:
+            state = "on"
+
+        entity._seed_from_state(BareState())
+        assert entity._last_on_rgb == original_rgb
+
+
+# -- Startup restore --
+
+
 class TestRestorePowerDefault:
-    """Default behavior (restore_power not set or False) — no commands to real light."""
+    """Default behavior (restore_power=False) - transparent, reads real light."""
 
     def test_default_is_false(self):
-        """restore_power defaults to False when not in config."""
         config_entry = make_config_entry(restore_power=None)
         entity = make_light_entity(config_entry)
         assert entity._restore_power is False
 
     def test_explicit_false(self):
-        """restore_power=False is respected."""
         config_entry = make_config_entry(restore_power=False)
         entity = make_light_entity(config_entry)
         assert entity._restore_power is False
 
     @pytest.mark.asyncio
-    async def test_restore_on_state_no_turn_on(self):
-        """When last state was ON and restore_power=False, don't call turn_on."""
+    async def test_reads_real_light_on(self):
+        """When real light is ON, wrapper state is ON, no commands sent."""
         config_entry = make_config_entry(restore_power=False)
-        entity = make_light_entity(config_entry)
+        entity = make_light_entity(
+            config_entry, wrapped_state="on", restored_state="off"
+        )
 
-        # Mock async_get_last_state to return ON
-        entity.async_get_last_state = AsyncMock(return_value=FakeState("on"))
+        await entity.async_added_to_hass()
 
-        # Run the restore portion of async_added_to_hass
-        restored_state = await entity.async_get_last_state()
-        if restored_state:
-            entity._attr_is_on = restored_state.state == "on"
-            entity.async_schedule_update_ha_state(True)
-            if entity._restore_power:
-                if entity.is_on:
-                    entity.hass.async_create_task(entity.async_turn_on())
-                else:
-                    entity.hass.async_create_task(entity.async_turn_off())
-
-        # Internal state should be ON
         assert entity._attr_is_on is True
-        # But no turn_on command sent
-        entity.async_turn_on.assert_not_awaited()
         entity.hass.async_create_task.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_restore_off_state_no_turn_off(self):
-        """When last state was OFF and restore_power=False, don't call turn_off."""
+    async def test_reads_real_light_off(self):
+        """When real light is OFF, wrapper state is OFF, no commands sent."""
         config_entry = make_config_entry(restore_power=False)
-        entity = make_light_entity(config_entry)
+        entity = make_light_entity(
+            config_entry, wrapped_state="off", restored_state="on"
+        )
 
-        entity.async_get_last_state = AsyncMock(return_value=FakeState("off"))
-
-        restored_state = await entity.async_get_last_state()
-        if restored_state:
-            entity._attr_is_on = restored_state.state == "on"
-            entity.async_schedule_update_ha_state(True)
-            if entity._restore_power:
-                if entity.is_on:
-                    entity.hass.async_create_task(entity.async_turn_on())
-                else:
-                    entity.hass.async_create_task(entity.async_turn_off())
+        await entity.async_added_to_hass()
 
         assert entity._attr_is_on is False
-        entity.async_turn_off.assert_not_awaited()
+        entity.hass.async_create_task.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_cached_when_real_unavailable(self):
+        """When real light unavailable, fall back to cached state."""
+        config_entry = make_config_entry(restore_power=False)
+        entity = make_light_entity(
+            config_entry, wrapped_state=None, restored_state="on"
+        )
+
+        await entity.async_added_to_hass()
+
+        assert entity._attr_is_on is True
+        entity.hass.async_create_task.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_no_state_available(self):
+        """When neither real nor cached state available, is_on stays None."""
+        config_entry = make_config_entry(restore_power=False)
+        entity = make_light_entity(
+            config_entry, wrapped_state=None, restored_state=None
+        )
+
+        await entity.async_added_to_hass()
+
+        assert entity._attr_is_on is None
         entity.hass.async_create_task.assert_not_called()
 
 
 class TestRestorePowerEnabled:
-    """When restore_power=True, commands ARE sent to the real light (old behavior)."""
+    """When restore_power=True, commands ARE sent to the real light."""
 
     def test_explicit_true(self):
-        """restore_power=True is respected."""
         config_entry = make_config_entry(restore_power=True)
         entity = make_light_entity(config_entry)
         assert entity._restore_power is True
 
     @pytest.mark.asyncio
-    async def test_restore_on_state_calls_turn_on(self):
-        """When last state was ON and restore_power=True, call turn_on."""
+    async def test_restore_on_calls_turn_on(self):
+        """When cached state was ON and restore_power=True, call turn_on."""
         config_entry = make_config_entry(restore_power=True)
-        entity = make_light_entity(config_entry)
+        entity = make_light_entity(
+            config_entry, wrapped_state=None, restored_state="on"
+        )
 
-        entity.async_get_last_state = AsyncMock(return_value=FakeState("on"))
-
-        restored_state = await entity.async_get_last_state()
-        if restored_state:
-            entity._attr_is_on = restored_state.state == "on"
-            entity.async_schedule_update_ha_state(True)
-            if entity._restore_power:
-                if entity.is_on:
-                    entity.hass.async_create_task(entity.async_turn_on())
-                else:
-                    entity.hass.async_create_task(entity.async_turn_off())
+        await entity.async_added_to_hass()
 
         assert entity._attr_is_on is True
         entity.hass.async_create_task.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_restore_off_state_calls_turn_off(self):
-        """When last state was OFF and restore_power=True, call turn_off."""
+    async def test_restore_off_calls_turn_off(self):
+        """When cached state was OFF and restore_power=True, call turn_off."""
         config_entry = make_config_entry(restore_power=True)
-        entity = make_light_entity(config_entry)
+        entity = make_light_entity(
+            config_entry, wrapped_state=None, restored_state="off"
+        )
 
-        entity.async_get_last_state = AsyncMock(return_value=FakeState("off"))
-
-        restored_state = await entity.async_get_last_state()
-        if restored_state:
-            entity._attr_is_on = restored_state.state == "on"
-            entity.async_schedule_update_ha_state(True)
-            if entity._restore_power:
-                if entity.is_on:
-                    entity.hass.async_create_task(entity.async_turn_on())
-                else:
-                    entity.hass.async_create_task(entity.async_turn_off())
+        await entity.async_added_to_hass()
 
         assert entity._attr_is_on is False
         entity.hass.async_create_task.assert_called_once()
 
-
-class TestRestorePowerNoState:
-    """When there's no restored state, nothing should happen regardless of config."""
-
     @pytest.mark.asyncio
-    async def test_no_restored_state_does_nothing(self):
-        """No previous state — no restore, no commands."""
+    async def test_no_cached_state_does_nothing(self):
+        """No cached state - no restore, no commands."""
         config_entry = make_config_entry(restore_power=True)
-        entity = make_light_entity(config_entry)
+        entity = make_light_entity(
+            config_entry, wrapped_state="on", restored_state=None
+        )
 
-        entity.async_get_last_state = AsyncMock(return_value=None)
-
-        restored_state = await entity.async_get_last_state()
-        if restored_state:
-            entity._attr_is_on = restored_state.state == "on"
-            entity.async_schedule_update_ha_state(True)
-            if entity._restore_power:
-                if entity.is_on:
-                    entity.hass.async_create_task(entity.async_turn_on())
-                else:
-                    entity.hass.async_create_task(entity.async_turn_off())
+        await entity.async_added_to_hass()
 
         entity.hass.async_create_task.assert_not_called()
-        entity.async_schedule_update_ha_state.assert_not_called()
+
+
+# -- Startup seeding --
+
+
+class TestStartupSeed:
+    """Startup restore seeds _last_on_rgb/_last_brightness from best source."""
+
+    @pytest.mark.asyncio
+    async def test_transparent_seeds_from_real_light(self):
+        """restore_power=False seeds tracking from the wrapped light's state."""
+        config_entry = make_config_entry(restore_power=False)
+        wrapped = FakeState(
+            "on", {"rgb_color": (255, 100, 50), "brightness": 180}
+        )
+        entity = make_light_entity(
+            config_entry, wrapped_state=wrapped, restored_state="off"
+        )
+
+        await entity.async_added_to_hass()
+
+        assert entity._last_on_rgb == (255, 100, 50)
+        assert entity._last_brightness == 180
+
+    @pytest.mark.asyncio
+    async def test_transparent_seeds_from_cached_fallback(self):
+        """When real light unavailable, seeds from cached state."""
+        config_entry = make_config_entry(restore_power=False)
+        cached = FakeState(
+            "on", {"rgb_color": (200, 150, 100), "brightness": 120}
+        )
+        entity = make_light_entity(
+            config_entry, wrapped_state=None, restored_state=cached
+        )
+
+        await entity.async_added_to_hass()
+
+        assert entity._last_on_rgb == (200, 150, 100)
+        assert entity._last_brightness == 120
+
+    @pytest.mark.asyncio
+    async def test_restore_power_seeds_from_cached(self):
+        """restore_power=True seeds tracking from cached state."""
+        config_entry = make_config_entry(restore_power=True)
+        cached = FakeState(
+            "on", {"rgb_color": (200, 150, 100), "brightness": 200}
+        )
+        entity = make_light_entity(
+            config_entry, wrapped_state=None, restored_state=cached
+        )
+
+        await entity.async_added_to_hass()
+
+        assert entity._last_on_rgb == (200, 150, 100)
+        assert entity._last_brightness == 200
+
+    @pytest.mark.asyncio
+    async def test_no_state_keeps_defaults(self):
+        """When no state available, defaults are preserved."""
+        config_entry = make_config_entry(restore_power=False)
+        entity = make_light_entity(
+            config_entry, wrapped_state=None, restored_state=None
+        )
+        default_rgb = entity._last_on_rgb
+        default_brightness = entity._last_brightness
+
+        await entity.async_added_to_hass()
+
+        assert entity._last_on_rgb == default_rgb
+        assert entity._last_brightness == default_brightness
+
+
+# -- Worker spawn order --
+
+
+class TestWorkerSpawnOrder:
+    """Worker task must be spawned after state restore completes."""
+
+    @pytest.mark.asyncio
+    async def test_worker_spawns_after_state_restore(self):
+        config_entry = make_config_entry(restore_power=False)
+        entity = make_light_entity(
+            config_entry, wrapped_state="on", restored_state="on"
+        )
+
+        call_order = []
+        original_get_last_state = entity.async_get_last_state
+
+        async def tracked_get_last_state():
+            call_order.append("get_last_state")
+            return await original_get_last_state()
+
+        def tracked_create_background_task(*args, **kwargs):
+            call_order.append("create_background_task")
+
+        entity.async_get_last_state = tracked_get_last_state
+        config_entry.async_create_background_task = tracked_create_background_task
+
+        await entity.async_added_to_hass()
+
+        assert "get_last_state" in call_order
+        assert "create_background_task" in call_order
+        get_idx = call_order.index("get_last_state")
+        spawn_idx = call_order.index("create_background_task")
+        assert spawn_idx > get_idx, (
+            f"Worker spawned at {spawn_idx} but get_last_state at {get_idx}. "
+            f"Worker must spawn AFTER state restore. Order: {call_order}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_worker_spawns_even_without_restored_state(self):
+        config_entry = make_config_entry(restore_power=False)
+        entity = make_light_entity(
+            config_entry, wrapped_state=None, restored_state=None
+        )
+
+        await entity.async_added_to_hass()
+
+        config_entry.async_create_background_task.assert_called_once()


### PR DESCRIPTION
## Summary

- Add `_seed_from_state()` helper to sync `_last_on_rgb`/`_last_brightness` from real light state instead of using hardcoded `WARM_WHITE_RGB`/`255` defaults
- **Startup**: read real light via `hass.states.get()` (transparent mode, default) or cached state (`restore_power=True`), seed tracking, send no commands unless `restore_power` is enabled
- **Runtime**: when no notification is active, accept external light changes instead of resetting sequences (which re-applies stale state)
- **Worker spawn**: moved after state restore to avoid racing with init
- Add `restore_power` config option (default `False`) for power outage recovery use case

## Design principle

A wrapper should be transparent when not actively notifying. External changes to the real light (Siri, Hue app, API) should be accepted, not fought.

## What changed

### Startup restore (`async_added_to_hass`)

| Behavior | Before | After |
|----------|--------|--------|
| `_last_on_rgb` on startup | `WARM_WHITE_RGB` (hardcoded) | Seeded from real light state |
| `_last_brightness` on startup | `255` (hardcoded) | Seeded from real light state |
| Commands sent | `async_turn_on()` with wrong defaults | None (transparent mode) |
| Worker spawn | Before `async_get_last_state` (race) | After state restore completes |

### Runtime (`_handle_wrapped_light_change`)

| Behavior | Before | After |
|----------|--------|--------|
| External change (no notification) | WARNING + `_reset_running_sequences` + re-apply stale state | DEBUG + `_seed_from_state` + accept change |
| External change (notification active) | Reset sequences (unchanged) | Reset sequences (unchanged) |

### `restore_power` config

- `False` (default): transparent mode - reads real light, sends no commands on startup
- `True`: power outage recovery - uses cached state, sends `turn_on`/`turn_off` to real light

## Test plan

- [x] 22 unit tests covering `_seed_from_state`, startup restore (both modes), startup seeding, and worker spawn order
- [x] Before/after HA debug logs captured on real hardware (see below)
- [x] Startup blast reproduction: light no longer blasts to full-brightness warm white on restart
- [x] Runtime acceptance: external light changes accepted (DEBUG log) instead of fought (WARNING + sequence reset)
- [x] Notification override still works when notification is active

<details>
<summary>Before fix: upstream code (startup blast + runtime fighting)</summary>

### Bug 1: Startup Blast

After HA restart, the wrapper restored with hardcoded defaults:

```
Wrapper state after restart:
  State: on
  brightness: 255 (100%)
  rgb_color: [255, 249, 216] (WARM_WHITE_RGB hardcoded default)
  color_temp_kelvin: 4787 (exceeds 3200K max)

Real light state after restart:
  State: off (wrapper sent turn_on but wrapped light wasn't init'd yet)
```

Log evidence:
```
ERROR [custom_components.color_notify.light]
  [Light] Test Light Notify failed to set wrapped light, real state unknown
```

The worker spawned before the wrapped light entity was available (race condition),
then tried to apply WARM_WHITE_RGB/255 defaults via `_process_sequence_list`.

### Bug 2: Runtime Fighting (External Changes Rejected)

After turning on the real light directly via API (2700K, brightness 128), the
wrapper logged 3 "unexpected event" warnings and reset its sequences:

```
WARNING [custom_components.color_notify.light]
  light.light_test_light_notify received unexpected event
  {old_state: off -> new_state: on, brightness=254, rgb=(255,249,216)}

WARNING [custom_components.color_notify.light]
  light.light_test_light_notify received unexpected event
  {old_state: brightness=254 -> new_state: brightness=128}

WARNING [custom_components.color_notify.light]
  light.light_test_light_notify received unexpected event
  {old_state: brightness=128,xy -> new_state: brightness=128,color_temp=2702K}
```

Each "unexpected event" triggers `_reset_running_sequences()`, which clears
`_last_set_color` and wakes the worker loop to re-apply `_last_on_rgb` (the stale
WARM_WHITE_RGB from startup). 3 queue wake items confirm the reset-and-reapply cycle:

```
INFO [[Light] Test Light Notify] Got queue item: [_QueueEntry(action=None)]
INFO [[Light] Test Light Notify] Got queue item: [_QueueEntry(action=None)]
INFO [[Light] Test Light Notify] Got queue item: [_QueueEntry(action=None)]
```

</details>

<details>
<summary>After fix (transparent startup + runtime acceptance)</summary>

### Fix 1: Startup - No Blast

After HA restart, the wrapper read the real light state instead of using defaults:

```
WARNING [custom_components.color_notify.light]
  [Light] Test Light Notify startup: transparent, real light=on,
  seeded rgb=(255, 167, 88) brightness=128, no commands sent
```

Post-restart wrapper state:
```
State: on, brightness=255, rgb=[255, 167, 88], kelvin=1874
```

Key differences vs upstream:
- rgb=[255, 167, 88] (actual 2700K color) vs [255, 249, 216] (WARM_WHITE_RGB default)
- "no commands sent" - real light was not touched
- No "failed to set wrapped light" error (worker spawned after init)

### Fix 2: Runtime - External Changes Accepted

Changed real light to 3000K/brightness 200 via direct API call. Logs show acceptance
instead of fighting:

```
DEBUG light.light_test_light_notify accepting external change
DEBUG light.light_test_light_notify accepting external change
DEBUG light.light_test_light_notify accepting external change
```

Key differences vs upstream:
- 3x "accepting external change" (DEBUG) vs 3x "received unexpected event" (WARNING)
- Wrapper updated its rgb to [255, 177, 110] (3000K) instead of resetting to stale state
- No `_reset_running_sequences` / `_wake_loop` cycle
- No re-application of stale WARM_WHITE_RGB

</details>

<details>
<summary>Comparison table</summary>

| Behavior | Upstream (before) | After fix |
|----------|-------------------|-----------|
| Startup `_last_on_rgb` | (255, 249, 216) WARM_WHITE | (255, 167, 88) from real light |
| Startup `_last_brightness` | 255 (hardcoded) | 128 (from real light) |
| Startup commands | turn_on with wrong color | no commands |
| Worker spawn | before init (race) | after state restore |
| External change (idle) | WARNING + reset sequences | DEBUG + accept change |
| External change effect | re-applies stale state | updates wrapper tracking |

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)