### PR TITLE
 Fix light icon not dimming, add event log

### DIFF
--- a/custom_components/color_notify/__init__.py
+++ b/custom_components/color_notify/__init__.py
@@ -8,7 +8,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_TYPE, Platform
 from homeassistant.core import HomeAssistant
 
-from .const import CONF_ENTRY, TYPE_LIGHT, TYPE_POOL
+from .const import CONF_ENABLE_EVENT_LOG, CONF_ENTRY, CONF_LOADED_PLATFORMS, TYPE_LIGHT, TYPE_POOL
 from .utils.hass_data import HassData
 
 _LOGGER = logging.getLogger(__name__)
@@ -27,7 +27,22 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     ok = True
     item_type = entry.data.get(CONF_TYPE, None)
     if item_type == TYPE_LIGHT:
+        # Light must be set up first: it creates the log entity and stores it
+        # in runtime_data so the sensor platform can retrieve it.
         await hass.config_entries.async_forward_entry_setups(entry, [Platform.LIGHT])
+        loaded_platforms: list[Platform] = [Platform.LIGHT]
+        enable_log = entry.options.get(
+            CONF_ENABLE_EVENT_LOG,
+            entry.data.get(CONF_ENABLE_EVENT_LOG, True),
+        )
+        if enable_log:
+            await hass.config_entries.async_forward_entry_setups(
+                entry, [Platform.SENSOR]
+            )
+            loaded_platforms.append(Platform.SENSOR)
+        HassData.get_config_entry_runtime_data(entry.entry_id)[
+            CONF_LOADED_PLATFORMS
+        ] = loaded_platforms
         entry.async_on_unload(entry.add_update_listener(handle_config_updated))
     elif item_type == TYPE_POOL:
         # Register to reload config if options flow updates it
@@ -49,7 +64,9 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
     item_type = entry.data.get(CONF_TYPE, None)
     if item_type == TYPE_LIGHT:
-        await hass.config_entries.async_unload_platforms(entry, [Platform.LIGHT])
+        runtime_data = HassData.get_config_entry_runtime_data(entry.entry_id)
+        platforms = runtime_data.get(CONF_LOADED_PLATFORMS, [Platform.LIGHT])
+        await hass.config_entries.async_unload_platforms(entry, platforms)
     elif item_type == TYPE_POOL:
         await hass.config_entries.async_unload_platforms(entry, [Platform.SWITCH])
     else:

--- a/custom_components/color_notify/config_flow.py
+++ b/custom_components/color_notify/config_flow.py
@@ -32,9 +32,10 @@ from homeassistant.helpers import entity_registry as er, selector
 import homeassistant.helpers.config_validation as cv
 
 from .const import (
-    CONF_ENTRY,
     CONF_DELETE,
     CONF_DYNAMIC_PRIORITY,
+    CONF_ENABLE_EVENT_LOG,
+    CONF_ENTRY,
     CONF_EXPIRE_ENABLED,
     CONF_NOTIFY_PATTERN,
     CONF_NTFCTN_ENTRIES,
@@ -107,6 +108,7 @@ ADD_LIGHT_DEFAULTS = {
     CONF_DELAY: True,
     CONF_DELAY_TIME: {"seconds": 5},
     CONF_PEEK_TIME: {"seconds": 5},
+    CONF_ENABLE_EVENT_LOG: True,
 }
 ADD_LIGHT_SCHEMA = vol.Schema(
     {
@@ -134,6 +136,9 @@ ADD_LIGHT_SCHEMA = vol.Schema(
         vol.Optional(
             CONF_PEEK_TIME, default=ADD_LIGHT_DEFAULTS[CONF_PEEK_TIME]
         ): selector.DurationSelector(selector.DurationSelectorConfig()),
+        vol.Required(
+            CONF_ENABLE_EVENT_LOG, default=ADD_LIGHT_DEFAULTS[CONF_ENABLE_EVENT_LOG]
+        ): cv.boolean,
     }
 )
 
@@ -528,7 +533,58 @@ class LightOptionsFlowHandler(HassDataOptionsFlow):
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Launch the options flow."""
-        return await self.async_step_subscriptions(user_input)
+        return self.async_show_menu(
+            step_id="light_init",
+            menu_options=["light_options", "subscriptions"],
+        )
+
+    async def async_step_light_options(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Show and save the configurable light settings."""
+        if user_input is not None:
+            return await self._async_trigger_conf_update(
+                data=self._config_entry.options
+                | {
+                    CONF_ENABLE_EVENT_LOG: user_input[CONF_ENABLE_EVENT_LOG],
+                    CONF_DYNAMIC_PRIORITY: user_input[CONF_DYNAMIC_PRIORITY],
+                    CONF_PRIORITY: user_input[CONF_PRIORITY],
+                }
+            )
+
+        current = self._config_entry
+        schema = vol.Schema(
+            {
+                vol.Required(
+                    CONF_ENABLE_EVENT_LOG,
+                    default=current.options.get(
+                        CONF_ENABLE_EVENT_LOG,
+                        current.data.get(CONF_ENABLE_EVENT_LOG, True),
+                    ),
+                ): cv.boolean,
+                vol.Required(
+                    CONF_DYNAMIC_PRIORITY,
+                    default=current.options.get(
+                        CONF_DYNAMIC_PRIORITY,
+                        current.data.get(CONF_DYNAMIC_PRIORITY, True),
+                    ),
+                ): cv.boolean,
+                vol.Optional(
+                    CONF_PRIORITY,
+                    default=current.options.get(
+                        CONF_PRIORITY,
+                        current.data.get(CONF_PRIORITY, DEFAULT_PRIORITY),
+                    ),
+                ): selector.NumberSelector(
+                    selector.NumberSelectorConfig(
+                        mode=selector.NumberSelectorMode.BOX,
+                        min=1,
+                        max=MAXIMUM_PRIORITY,
+                    )
+                ),
+            }
+        )
+        return self.async_show_form(step_id="light_options", data_schema=schema)
 
     async def async_step_subscriptions(
         self, user_input: dict[str, Any] | None = None
@@ -562,9 +618,7 @@ class LightOptionsFlowHandler(HassDataOptionsFlow):
     async def async_step_finish_subscriptions(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
-        """Finalize adding the notification."""
-        # Add to the entry to sub ensuring defaults are set
-        # self._get_ntfctn_entries().update(SUBSCRIPTION_DEFAULTS | user_input)
+        """Finalize updating subscriptions, preserving all other options."""
         return await self._async_trigger_conf_update(
-            data={CONF_SUBSCRIPTION: user_input}
+            data=self._config_entry.options | {CONF_SUBSCRIPTION: user_input}
         )

--- a/custom_components/color_notify/const.py
+++ b/custom_components/color_notify/const.py
@@ -21,6 +21,9 @@ CONF_ENTRY: Final = "entry"
 CONF_PEEK_TIME: Final = "peek_time"
 CONF_PEEK_ENABLED: Final = "peek_enabled"
 CONF_DYNAMIC_PRIORITY: Final = "dynamic_priority"
+CONF_ENABLE_EVENT_LOG: Final = "enable_event_log"
+CONF_EVENT_ENTITY: Final = "event_entity"
+CONF_LOADED_PLATFORMS: Final = "loaded_platforms"
 
 ACTION_CYCLE_SAME: Final = "cycle_same"
 

--- a/custom_components/color_notify/light.py
+++ b/custom_components/color_notify/light.py
@@ -929,10 +929,17 @@ class NotificationLightEntity(LightEntity, RestoreEntity):
             h, s, v = color_RGB_to_hsv(*self._last_on_rgb)
             brightness = (255 / 100) * v  # Re-scale 'v' from 0-100 to 0-255
             data[ATTR_BRIGHTNESS] = brightness
-            data[ATTR_COLOR_TEMP_KELVIN] = color_temperature_to_rgb
             x, y = color_hs_to_xy(h, s)
             data[ATTR_XY_COLOR] = (x, y)
             data[ATTR_COLOR_TEMP_KELVIN] = color_xy_to_temperature(x, y)
+        else:
+            # Explicit None values required: HA skips merging state_attributes
+            # when the dict is falsy, leaving stale on-state values in the HA state.
+            data[ATTR_COLOR_MODE] = None
+            data[ATTR_BRIGHTNESS] = None
+            data[ATTR_RGB_COLOR] = None
+            data[ATTR_XY_COLOR] = None
+            data[ATTR_COLOR_TEMP_KELVIN] = None
         return data
 
     @property

--- a/custom_components/color_notify/light.py
+++ b/custom_components/color_notify/light.py
@@ -763,9 +763,7 @@ class NotificationLightEntity(LightEntity, RestoreEntity):
                 p = existing_seq.priority
                 natural = p - MAXIMUM_PRIORITY if p > MAXIMUM_PRIORITY else p
                 log_trigger = f"{friendly} (pri {natural}) disabled"
-            else:
-                log_trigger = f"{friendly} disabled"
-            await self._remove_sequence(notify_id, log_trigger=log_trigger)
+                await self._remove_sequence(notify_id, log_trigger=log_trigger)
 
     async def _handle_wrapped_light_change(
         self, event: Event[EventStateChangedData]

--- a/custom_components/color_notify/light.py
+++ b/custom_components/color_notify/light.py
@@ -52,6 +52,8 @@ from .const import (
     CONF_ADD,
     CONF_DELETE,
     CONF_DYNAMIC_PRIORITY,
+    CONF_ENABLE_EVENT_LOG,
+    CONF_EVENT_ENTITY,
     CONF_EXPIRE_ENABLED,
     CONF_NOTIFY_PATTERN,
     CONF_PEEK_ENABLED,
@@ -67,6 +69,7 @@ from .const import (
     TYPE_POOL,
     WARM_WHITE_RGB,
 )
+from .sensor import ColorNotifyLogEntity
 from .utils.hass_data import HassData
 from .utils.light_sequence import ColorInfo, LightSequence
 
@@ -85,7 +88,15 @@ async def async_setup_entry(
     )
     unique_id = config_entry.entry_id
     runtime_data = HassData.get_config_entry_runtime_data(config_entry.entry_id)
-    new_entity = NotificationLightEntity(unique_id, wrapped_entity_id, config_entry)
+    enable_log = config_entry.options.get(
+        CONF_ENABLE_EVENT_LOG,
+        config_entry.data.get(CONF_ENABLE_EVENT_LOG, True),
+    )
+    log_entity: ColorNotifyLogEntity | None = None
+    if enable_log:
+        log_entity = ColorNotifyLogEntity(unique_id, config_entry)
+        runtime_data[CONF_EVENT_ENTITY] = log_entity
+    new_entity = NotificationLightEntity(unique_id, wrapped_entity_id, config_entry, log_entity)
     runtime_data[CONF_ENTITIES] = new_entity
     async_add_entities([new_entity])
 
@@ -217,6 +228,7 @@ class _QueueEntry:
     action: str | None = None
     notify_id: str | None = None
     sequence: _NotificationSequence | None = None
+    log_trigger: str | None = None
 
 
 class NotificationLightEntity(LightEntity, RestoreEntity):
@@ -229,6 +241,7 @@ class NotificationLightEntity(LightEntity, RestoreEntity):
         unique_id: str,
         wrapped_entity_id: str,
         config_entry: ConfigEntry,
+        log_entity: ColorNotifyLogEntity | None,
     ) -> None:
         """Initialize light."""
         super().__init__()
@@ -237,6 +250,7 @@ class NotificationLightEntity(LightEntity, RestoreEntity):
         self._attr_name: str = config_entry.title
         self._attr_unique_id: str = unique_id
         self._config_entry: ConfigEntry = config_entry
+        self._event_logger: ColorNotifyLogEntity | None = log_entity
 
         self._running_sequences: dict[str, _NotificationSequence] = {}
         self._active_sequences: dict[str, _NotificationSequence] = {}
@@ -404,12 +418,15 @@ class NotificationLightEntity(LightEntity, RestoreEntity):
             ret.append(sequence)
         return ret
 
-    async def _process_sequence_list(self):
+    async def _process_sequence_list(self, log_trigger: str | None = None) -> None:
         """Process the sequence list for the current display color and set it on the bulb."""
         top_sequences: list[_NotificationSequence] = self._get_top_sequences()
         if len(top_sequences) > 0:
             top_sequence = top_sequences[0]
             top_priority = top_sequence.priority
+
+            # Log the notification event with the current display state.
+            self._log_display_state(top_sequences, log_trigger)
 
             # Ensure all top sequences are in the running list
             for sequence in top_sequences:
@@ -486,9 +503,11 @@ class NotificationLightEntity(LightEntity, RestoreEntity):
             else 0
         )
 
+        pending_trigger: str | None = None
         while True:
             # Update the bulb based off the current sequence list
-            await self._process_sequence_list()
+            await self._process_sequence_list(log_trigger=pending_trigger)
+            pending_trigger = None
 
             # Schedule cycling through same-priority notifications
             if (
@@ -532,33 +551,29 @@ class NotificationLightEntity(LightEntity, RestoreEntity):
                     if item.notify_id in self._active_sequences:
                         _LOGGER.warning("%s already in active list", item.notify_id)
 
-                    async def restore_priority(
-                        _,
-                        priority=item.sequence.priority,
-                        notify_id=item.notify_id,
-                    ):
-                        # Restore the priority and wake the event loop to resort the notifications
-                        sequence = self._active_sequences.get(notify_id)
-                        if sequence is not None:
-                            sequence.priority = priority
-                            _LOGGER.debug(
-                                "Restoring %s priority to %d",
-                                notify_id,
-                                sequence.priority,
-                            )
-                            self._sort_active_sequences()
-                            await self._wake_loop()
-
-                    # Temporarily give high priority for peeks
+                    # Temporarily give high priority for peeks, but only when
+                    # needed: skip the boost when this notification's natural
+                    # priority is already at or above the current top, so it
+                    # would show without any boost.
+                    # _active_sequences is kept sorted descending, so the first
+                    # value is always the current top priority.
+                    current_top_priority = next(
+                        iter(self._active_sequences.values())
+                    ).priority
+                    # Strict less-than: a tie means the new notification
+                    # joins the existing same-priority rotation rather than
+                    # peeking in front of it.
                     if (
                         peek_duration > 0
                         and item.sequence.peek_enabled
                         and item.notify_id != STATE_OFF
+                        and item.sequence.priority <= current_top_priority
                     ):
                         auto_clears = (
                             item.sequence.clear_delay == 0
                             and not item.sequence.loops_forever
                         )
+                        original_priority = item.sequence.priority
                         item.sequence.priority += MAXIMUM_PRIORITY
                         _LOGGER.debug(
                             "Boosting %s priority to %d for %f seconds",
@@ -567,6 +582,26 @@ class NotificationLightEntity(LightEntity, RestoreEntity):
                             peek_duration,
                         )
                         if not auto_clears:
+                            async def restore_priority(
+                                _,
+                                priority=original_priority,
+                                notify_id=item.notify_id,
+                            ):
+                                # Restore the priority and wake the event loop to resort the notifications
+                                sequence = self._active_sequences.get(notify_id)
+                                if sequence is not None:
+                                    sequence.priority = priority
+                                    _LOGGER.debug(
+                                        "Restoring %s priority to %d",
+                                        notify_id,
+                                        sequence.priority,
+                                    )
+                                    self._sort_active_sequences()
+                                    trigger = (
+                                        f"{self._friendly_name(notify_id)}"
+                                        f" (pri {priority}) peek expired"
+                                    )
+                                    await self._wake_loop(log_trigger=trigger)
                             async_call_later(self.hass, peek_duration, restore_priority)
 
                     # Add the new sequence in, sorted by priority
@@ -587,6 +622,8 @@ class NotificationLightEntity(LightEntity, RestoreEntity):
                             new_dict[it_id] = it_seq
                         self._active_sequences = new_dict
 
+                if item.log_trigger is not None:
+                    pending_trigger = item.log_trigger
                 self._task_queue.task_done()
 
     @callback
@@ -622,29 +659,72 @@ class NotificationLightEntity(LightEntity, RestoreEntity):
 
         return ColorInfo((r, g, b), brightness_total)
 
-    async def _wake_loop(self) -> None:
+    async def _wake_loop(self, log_trigger: str | None = None) -> None:
         """Wake the event loop to process light sequences."""
-        await self._task_queue.put(_QueueEntry(action=None, notify_id=None))
+        await self._task_queue.put(_QueueEntry(action=None, notify_id=None, log_trigger=log_trigger))
 
     async def _add_sequence(
-        self, notify_id: str, sequence: _NotificationSequence
+        self, notify_id: str, sequence: _NotificationSequence, log_trigger: str | None = None
     ) -> None:
         """Add a sequence to this light."""
         await self._task_queue.put(
-            _QueueEntry(action=CONF_ADD, notify_id=notify_id, sequence=sequence)
+            _QueueEntry(action=CONF_ADD, notify_id=notify_id, sequence=sequence, log_trigger=log_trigger)
         )
 
-    async def _remove_sequence(self, notify_id: str) -> None:
+    async def _remove_sequence(self, notify_id: str, log_trigger: str | None = None) -> None:
         """Remove a sequence from this light."""
-        await self._task_queue.put(_QueueEntry(notify_id=notify_id, action=CONF_DELETE))
+        await self._task_queue.put(_QueueEntry(notify_id=notify_id, action=CONF_DELETE, log_trigger=log_trigger))
 
     async def _reset_running_sequences(self) -> None:
-        """Immediately reset the running sequence list"""
+        """Immediately reset the running sequence list."""
         while self._running_sequences:
             seq_id, anim = self._running_sequences.popitem()
             await anim.stop()
         self._last_set_color = None
         await self._wake_loop()
+
+    @callback
+    def _friendly_name(self, entity_id: str) -> str:
+        """Return the friendly name of an entity, falling back to its entity_id."""
+        state = self.hass.states.get(entity_id)
+        if state:
+            return state.attributes.get("friendly_name") or entity_id
+        return entity_id
+
+    def _log_display_state(
+        self,
+        top_sequences: list[_NotificationSequence],
+        log_trigger: str | None = None,
+    ) -> None:
+        """Log a notification event combined with what is currently displaying.
+
+        Only logs when log_trigger is provided; the trigger string describes
+        what caused the change (enabled, disabled, or peek expired).
+        """
+        if self._event_logger is None or log_trigger is None:
+            return
+
+        top_ids = frozenset(s.notify_id for s in top_sequences)
+
+        if STATE_OFF in top_ids or None in top_ids:
+            displaying = "Off"
+        elif STATE_ON in top_ids:
+            displaying = "Light On"
+        else:
+            # Any sequence with priority > MAXIMUM_PRIORITY is showing via a
+            # temporary peek boost rather than its natural priority.
+            is_peek = any(s.priority > MAXIMUM_PRIORITY for s in top_sequences)
+            names = ", ".join(
+                self._friendly_name(s.notify_id)
+                for s in top_sequences
+                if s.notify_id not in (None, STATE_OFF, STATE_ON)
+            )
+            if is_peek:
+                displaying = f"{names} (peeking)"
+            else:
+                displaying = f"{names} (pri {top_sequences[0].priority})"
+
+        self._event_logger.update_message(f"{log_trigger}, displaying {displaying}")
 
     def _reset_expected_response_timeout(self):
         self._response_expected_expire_time = (
@@ -662,17 +742,30 @@ class NotificationLightEntity(LightEntity, RestoreEntity):
                 self._config_entry.title,
                 notify_id,
             )
-            await self._remove_sequence(notify_id)
+            await self._remove_sequence(
+                notify_id, log_trigger=f"{notify_id} removed (renamed or deleted)"
+            )
             return
 
         is_on = event.data["new_state"].state == STATE_ON
+        # The friendly name is already in the event's new_state attributes;
+        # read it directly rather than doing a second hass.states.get lookup.
+        friendly = event.data["new_state"].attributes.get("friendly_name") or notify_id
         if is_on:
             sequence = self._create_sequence_from_attr(
                 event.data["new_state"].attributes, notify_id
             )
-            await self._add_sequence(notify_id, sequence)
+            log_trigger = f"{friendly} (pri {sequence.priority}) enabled"
+            await self._add_sequence(notify_id, sequence, log_trigger=log_trigger)
         else:
-            await self._remove_sequence(notify_id)
+            existing_seq = self._active_sequences.get(notify_id)
+            if existing_seq is not None:
+                p = existing_seq.priority
+                natural = p - MAXIMUM_PRIORITY if p > MAXIMUM_PRIORITY else p
+                log_trigger = f"{friendly} (pri {natural}) disabled"
+            else:
+                log_trigger = f"{friendly} disabled"
+            await self._remove_sequence(notify_id, log_trigger=log_trigger)
 
     async def _handle_wrapped_light_change(
         self, event: Event[EventStateChangedData]
@@ -801,14 +894,14 @@ class NotificationLightEntity(LightEntity, RestoreEntity):
             notify_id=STATE_ON,
         )
 
-        await self._add_sequence(STATE_ON, sequence)
+        await self._add_sequence(STATE_ON, sequence, log_trigger="Light turned on")
         self.async_write_ha_state()
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Handle a turn_off service call."""
         self._attr_is_on = False
         self.async_write_ha_state()
-        await self._remove_sequence(STATE_ON)
+        await self._remove_sequence(STATE_ON, log_trigger="Light turned off")
 
     async def async_toggle(self, **kwargs: Any) -> None:
         """Handle a toggle service call."""

--- a/custom_components/color_notify/sensor.py
+++ b/custom_components/color_notify/sensor.py
@@ -1,0 +1,54 @@
+"""Sensor platform for ColorNotify integration event logging."""
+
+from homeassistant.components.sensor import RestoreSensor
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import CONF_EVENT_ENTITY
+from .utils.hass_data import HassData
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the ColorNotify event log sensor for a light config entry."""
+    runtime_data = HassData.get_config_entry_runtime_data(config_entry.entry_id)
+    log_entity: ColorNotifyLogEntity = runtime_data[CONF_EVENT_ENTITY]
+    async_add_entities([log_entity])
+
+
+class ColorNotifyLogEntity(RestoreSensor):
+    """Event log sensor for a ColorNotify notification light.
+
+    State is always the most recent human-readable event message.  Because
+    every state change is recorded by the HA recorder, the entity's history
+    card becomes a timestamped log that answers "what caused that light to
+    turn on?"
+    """
+
+    _attr_should_poll = False
+    _attr_native_value: str | None = None
+
+    def __init__(self, light_unique_id: str, config_entry: ConfigEntry) -> None:
+        """Initialize the event log sensor."""
+        super().__init__()
+        self._attr_unique_id = f"{light_unique_id}_event_log"
+        self._attr_name = f"{config_entry.title} event log"
+
+    async def async_added_to_hass(self) -> None:
+        """Restore the last known message after a restart."""
+        await super().async_added_to_hass()
+        if (last_data := await self.async_get_last_sensor_data()) is not None:
+            self._attr_native_value = last_data.native_value
+
+    @callback
+    def update_message(self, message: str) -> None:
+        """Write a new log message; called directly by the associated NotificationLightEntity."""
+        if self.hass is None:
+            # Not yet added to HA; skip until setup is complete.
+            return
+        self._attr_native_value = message
+        self.async_write_ha_state()

--- a/custom_components/color_notify/strings.json
+++ b/custom_components/color_notify/strings.json
@@ -1,4 +1,11 @@
 {
+  "entity": {
+    "sensor": {
+      "event_log": {
+        "name": "Event log"
+      }
+    }
+  },
   "config": {
     "step": {
       "user": {
@@ -17,11 +24,31 @@
         "data": {
           "name": "Collection name"
         }
+      },
+      "new_light": {
+        "data": {
+          "enable_event_log": "Enable event log"
+        }
       }
     }
   },
   "options": {
     "step": {
+      "light_init": {
+        "description": "Configure light",
+        "menu_options": {
+          "light_options": "Change light settings",
+          "subscriptions": "Modify subscriptions"
+        }
+      },
+      "light_options": {
+        "description": "Change light settings",
+        "data": {
+          "enable_event_log": "Enable event log",
+          "dynamic_priority": "Dynamic 'On' priority",
+          "priority": "Minimum 'On' priority"
+        }
+      },
       "pool_init": {
         "description": "Configure Pool Items",
         "menu_options": {

--- a/custom_components/color_notify/translations/en.json
+++ b/custom_components/color_notify/translations/en.json
@@ -1,4 +1,11 @@
 {
+  "entity": {
+    "sensor": {
+      "event_log": {
+        "name": "Event log"
+      }
+    }
+  },
   "config": {
     "step": {
       "user": {
@@ -30,7 +37,8 @@
           "dynamic_priority": "Dynamic 'On' Priority (inherit active light priority + 0.5 when switched on)",
           "peek_time": "Duration to temporarily display lower-priority notifications",
           "delay": "Auto-cycle between same priority notifications",
-          "delay_time": "Auto-cycle delay"
+          "delay_time": "Auto-cycle delay",
+          "enable_event_log": "Enable event logging entity"
         }
       },
       "reconfigure_light": {
@@ -43,7 +51,8 @@
           "dynamic_priority": "Dynamic 'On' Priority (inherit active light priority + 0.5 when switched on)",
           "peek_time": "Duration to temporarily display lower-priority notifications",
           "delay": "Auto-cycle between same priority notifications",
-          "delay_time": "Auto-cycle delay"
+          "delay_time": "Auto-cycle delay",
+          "enable_event_log": "Enable event logging entity"
         }
       }
     }
@@ -103,11 +112,18 @@
         }
       },
       "light_init": {
-        "description": "Configure Light",
+        "description": "Configure light",
         "menu_options": {
-          "light_options": "Change Light Settings",
-          "subscriptions": "Modify light subscriptions",
-          "unique_id": ""
+          "light_options": "Change light settings",
+          "subscriptions": "Modify subscriptions"
+        }
+      },
+      "light_options": {
+        "description": "Change light settings",
+        "data": {
+          "enable_event_log": "Enable event logging entity",
+          "dynamic_priority": "Dynamic 'On' priority (inherit active light priority + 0.5 when switched on)",
+          "priority": "Minimum 'On' priority"
         }
       },
       "subscriptions": {
@@ -125,6 +141,7 @@
           "color_picker": "Default 'On' color of light",
           "priority": "Minimum 'On' priority.",
           "dynamic_priority": "Dynamic 'On' Priority (inherit active light priority + 0.5 when switched on)",
+          "enable_event_log": "Enable event logging entity",
           "peek_time": "Duration to temporarily display lower-priority notifications",
           "delay": "Auto-cycle between same priority notifications",
           "delay_time": "Auto-cycle delay"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,6 +9,7 @@ HA_MODULES = [
     "homeassistant",
     "homeassistant.components",
     "homeassistant.components.light",
+    "homeassistant.components.sensor",
     "homeassistant.components.switch",
     "homeassistant.config_entries",
     "homeassistant.const",
@@ -80,6 +81,27 @@ ha_switch.DOMAIN = "switch"
 
 ha_restore = sys.modules["homeassistant.helpers.restore_state"]
 ha_restore.RestoreEntity = type("RestoreEntity", (), {})
+
+
+class _StubRestoreSensor:
+    """Minimal stub for homeassistant.components.sensor.RestoreSensor."""
+
+    hass = None
+    _attr_native_value = None
+    _attr_should_poll = False
+
+    async def async_added_to_hass(self):
+        pass
+
+    async def async_get_last_sensor_data(self):
+        return None
+
+    def async_write_ha_state(self):
+        pass
+
+
+ha_sensor = sys.modules["homeassistant.components.sensor"]
+ha_sensor.RestoreSensor = _StubRestoreSensor
 
 ha_core = sys.modules["homeassistant.core"]
 ha_core.callback = lambda f: f

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -108,3 +108,39 @@ ha_core.callback = lambda f: f
 ha_core.Event = MagicMock()
 ha_core.EventStateChangedData = MagicMock()
 ha_core.HomeAssistant = MagicMock()
+
+# ---------------------------------------------------------------------------
+# Shared test helpers
+# ---------------------------------------------------------------------------
+
+# Safe to import here: const.py has no homeassistant dependencies.
+from custom_components.color_notify.const import DEFAULT_PRIORITY  # noqa: E402
+
+
+def make_config_entry(title: str = "[Light] Test Light") -> MagicMock:
+    """Return a standard MagicMock config entry for unit testing."""
+    entry = MagicMock()
+    entry.entry_id = "test_entry_id"
+    entry.title = title
+    entry.data = {
+        "type": "light",
+        "entity_id": "light.test",
+        "color_picker": [255, 249, 216],
+        "dynamic_priority": True,
+        "priority": DEFAULT_PRIORITY,
+        "delay": True,
+        "delay_time": {"seconds": 5},
+        "peek_time": {"seconds": 5},
+    }
+    entry.options = {}
+    entry.async_on_unload = MagicMock()
+
+    def _create_background_task(hass, coro, name="", **kwargs):
+        coro.close()
+        task = MagicMock()
+        task.cancel = MagicMock()
+        task.done = MagicMock(return_value=True)
+        return task
+
+    entry.async_create_background_task = MagicMock(side_effect=_create_background_task)
+    return entry

--- a/tests/test_event_log.py
+++ b/tests/test_event_log.py
@@ -2,6 +2,8 @@
 
 from unittest.mock import AsyncMock, MagicMock
 
+from conftest import make_config_entry
+
 from custom_components.color_notify.sensor import ColorNotifyLogEntity
 from custom_components.color_notify.light import (
     ColorInfo,
@@ -20,35 +22,15 @@ from homeassistant.const import STATE_OFF, STATE_ON
 # ---------------------------------------------------------------------------
 
 
-def _make_config_entry(title="[Light] Test Light"):
-    entry = MagicMock()
-    entry.entry_id = "test_entry_id"
-    entry.title = title
-    entry.data = {
-        "type": "light",
-        "entity_id": "light.test",
-        "color_picker": [255, 249, 216],
-        "dynamic_priority": True,
-        "priority": DEFAULT_PRIORITY,
-        "delay": True,
-        "delay_time": {"seconds": 5},
-        "peek_time": {"seconds": 5},
-    }
-    entry.options = {}
-    entry.async_create_background_task = MagicMock()
-    entry.async_on_unload = MagicMock()
-    return entry
-
-
 def _make_log_entity(title="[Light] Test Light"):
-    entry = _make_config_entry(title)
+    entry = make_config_entry(title)
     entity = ColorNotifyLogEntity(light_unique_id="test_id", config_entry=entry)
     return entity
 
 
 def _make_light_entity(log_entity=None, is_on=False):
     """Return (entity, entry) with an optional ColorNotifyLogEntity wired in."""
-    entry = _make_config_entry()
+    entry = make_config_entry()
     entity = NotificationLightEntity(
         unique_id="test_id",
         wrapped_entity_id="light.test",

--- a/tests/test_event_log.py
+++ b/tests/test_event_log.py
@@ -52,6 +52,15 @@ def _make_mock_logger():
     return logger
 
 
+def _seed_active_seq(entity, notify_id, priority=100):
+    """Insert a dummy active sequence for notify_id into entity._active_sequences."""
+    entity._active_sequences[notify_id] = _NotificationSequence(
+        notify_id=notify_id,
+        pattern=[ColorInfo((255, 0, 0), 255)],
+        priority=priority,
+    )
+
+
 # ---------------------------------------------------------------------------
 # ColorNotifyLogEntity unit tests
 # ---------------------------------------------------------------------------
@@ -414,7 +423,22 @@ class TestHandleStateChangeEventLog:
         assert f"pri 500" in item.log_trigger
 
     async def test_notification_removed_trigger_includes_friendly_name(self):
-        """Disabling a notification places a trigger with the friendly name in the queue."""
+        """Disabling an active notification logs the friendly name and 'disabled'."""
+        entity, _ = _make_light_entity()
+
+        notify_id = "switch.fire_alert"
+        _seed_active_seq(entity, notify_id)
+
+        await entity._handle_notification_change(
+            self._make_event(notify_id, STATE_OFF, {"friendly_name": "Fire Alert"})
+        )
+
+        item = entity._task_queue.get_nowait()
+        assert "Fire Alert" in item.log_trigger
+        assert "disabled" in item.log_trigger
+
+    async def test_notification_disabled_at_boot_skips_log(self):
+        """A notification that is off at boot (never active) produces no queue entry."""
         entity, _ = _make_light_entity()
 
         notify_id = "switch.fire_alert"
@@ -423,10 +447,7 @@ class TestHandleStateChangeEventLog:
             self._make_event(notify_id, STATE_OFF, {"friendly_name": "Fire Alert"})
         )
 
-        item = entity._task_queue.get_nowait()
-        assert item.log_trigger is not None
-        assert "Fire Alert" in item.log_trigger
-        assert "disabled" in item.log_trigger
+        assert entity._task_queue.empty()
 
     async def test_notification_removed_trigger_uses_natural_priority(self):
         """Disabled trigger uses the natural (un-boosted) priority even when sequence is peeking."""
@@ -435,13 +456,8 @@ class TestHandleStateChangeEventLog:
         entity, _ = _make_light_entity()
         notify_id = "switch.fire_alert"
 
-        # Simulate a sequence that is currently in the active list with a peek boost.
-        seq = _NotificationSequence(
-            notify_id=notify_id,
-            pattern=[ColorInfo((255, 0, 0), 255)],
-            priority=100 + MAXIMUM_PRIORITY,  # boosted; natural = 100
-        )
-        entity._active_sequences[notify_id] = seq
+        # Simulate a sequence that is currently peek-boosted; natural priority is 100.
+        _seed_active_seq(entity, notify_id, priority=100 + MAXIMUM_PRIORITY)
 
         await entity._handle_notification_change(
             self._make_event(notify_id, STATE_OFF, {"friendly_name": "Fire Alert"})
@@ -469,6 +485,7 @@ class TestHandleStateChangeEventLog:
         entity, _ = _make_light_entity()
 
         notify_id = "switch.unnamed"
+        _seed_active_seq(entity, notify_id)
 
         await entity._handle_notification_change(self._make_event(notify_id, STATE_OFF))
 

--- a/tests/test_event_log.py
+++ b/tests/test_event_log.py
@@ -1,0 +1,544 @@
+"""Tests for the ColorNotifyLogEntity and event-log integration in NotificationLightEntity."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+from custom_components.color_notify.sensor import ColorNotifyLogEntity
+from custom_components.color_notify.light import (
+    ColorInfo,
+    LIGHT_OFF_SEQUENCE,
+    LIGHT_ON_SEQUENCE,
+    NotificationLightEntity,
+    WARM_WHITE_RGB,
+    _NotificationSequence,
+)
+from custom_components.color_notify.const import DEFAULT_PRIORITY
+from homeassistant.const import STATE_OFF, STATE_ON
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_config_entry(title="[Light] Test Light"):
+    entry = MagicMock()
+    entry.entry_id = "test_entry_id"
+    entry.title = title
+    entry.data = {
+        "type": "light",
+        "entity_id": "light.test",
+        "color_picker": [255, 249, 216],
+        "dynamic_priority": True,
+        "priority": DEFAULT_PRIORITY,
+        "delay": True,
+        "delay_time": {"seconds": 5},
+        "peek_time": {"seconds": 5},
+    }
+    entry.options = {}
+    entry.async_create_background_task = MagicMock()
+    entry.async_on_unload = MagicMock()
+    return entry
+
+
+def _make_log_entity(title="[Light] Test Light"):
+    entry = _make_config_entry(title)
+    entity = ColorNotifyLogEntity(light_unique_id="test_id", config_entry=entry)
+    return entity
+
+
+def _make_light_entity(log_entity=None, is_on=False):
+    """Return (entity, entry) with an optional ColorNotifyLogEntity wired in."""
+    entry = _make_config_entry()
+    entity = NotificationLightEntity(
+        unique_id="test_id",
+        wrapped_entity_id="light.test",
+        config_entry=entry,
+        log_entity=log_entity,
+    )
+    entity.hass = MagicMock()
+    entity.hass.states.get.return_value = None
+    entity.async_write_ha_state = MagicMock()
+    entity.async_schedule_update_ha_state = MagicMock()
+    entity.async_turn_on = AsyncMock()
+    entity.async_turn_off = AsyncMock()
+    entity._attr_is_on = is_on
+    return entity, entry
+
+
+def _make_mock_logger():
+    logger = MagicMock(spec=ColorNotifyLogEntity)
+    return logger
+
+
+# ---------------------------------------------------------------------------
+# ColorNotifyLogEntity unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestColorNotifyLogEntity:
+    """Tests for ColorNotifyLogEntity state management."""
+
+    def test_unique_id_contains_light_id(self):
+        """Unique ID incorporates the parent light's unique_id."""
+        entity = _make_log_entity()
+        assert "test_id" in entity._attr_unique_id
+
+    def test_name_contains_title(self):
+        """Entity name incorporates the config entry title."""
+        entity = _make_log_entity("[Light] My Lamp")
+        assert "My Lamp" in entity._attr_name or "my lamp" in entity._attr_name.lower()
+
+    def test_initial_native_value_is_none(self):
+        """State is None before any message is written."""
+        entity = _make_log_entity()
+        assert entity._attr_native_value is None
+
+    def test_update_message_sets_native_value(self):
+        """update_message stores the message as the entity state."""
+        entity = _make_log_entity()
+        entity.hass = MagicMock()
+        entity.async_write_ha_state = MagicMock()
+
+        entity.update_message("Light turned on manually")
+
+        assert entity._attr_native_value == "Light turned on manually"
+
+    def test_update_message_calls_async_write_ha_state(self):
+        """update_message triggers a state write to HA."""
+        entity = _make_log_entity()
+        entity.hass = MagicMock()
+        entity.async_write_ha_state = MagicMock()
+
+        entity.update_message("hello")
+
+        entity.async_write_ha_state.assert_called_once()
+
+    def test_update_message_skips_when_hass_is_none(self):
+        """update_message is a no-op before the entity is added to HA."""
+        entity = _make_log_entity()
+        entity.hass = None  # not yet added
+        entity.async_write_ha_state = MagicMock()
+
+        entity.update_message("hello")
+
+        entity.async_write_ha_state.assert_not_called()
+        assert entity._attr_native_value is None
+
+    def test_update_message_overwrites_previous_value(self):
+        """Calling update_message twice keeps only the latest message."""
+        entity = _make_log_entity()
+        entity.hass = MagicMock()
+        entity.async_write_ha_state = MagicMock()
+
+        entity.update_message("first")
+        entity.update_message("second")
+
+        assert entity._attr_native_value == "second"
+
+    async def test_async_added_to_hass_restores_previous_message(self):
+        """Last log message is restored from storage after a restart."""
+        entity = _make_log_entity()
+        last_data = MagicMock()
+        last_data.native_value = "Notification 'Alert' added"
+        entity.async_get_last_sensor_data = AsyncMock(return_value=last_data)
+
+        await entity.async_added_to_hass()
+
+        assert entity._attr_native_value == "Notification 'Alert' added"
+
+    async def test_async_added_to_hass_with_no_prior_state(self):
+        """Missing prior state leaves native_value as None."""
+        entity = _make_log_entity()
+        entity.async_get_last_sensor_data = AsyncMock(return_value=None)
+
+        await entity.async_added_to_hass()
+
+        assert entity._attr_native_value is None
+
+
+# ---------------------------------------------------------------------------
+# NotificationLightEntity + event log — _process_sequence_list
+# ---------------------------------------------------------------------------
+
+_TEST_TRIGGER = f"Test Notification (pri {DEFAULT_PRIORITY}) enabled"
+
+
+class TestProcessSequenceListEventLog:
+    """Event log messages emitted by _log_showing_if_changed (called from _process_sequence_list)."""
+
+    async def _run_with_sequence(self, entity, seq, notify_id, log_trigger=_TEST_TRIGGER):
+        """Helper: wire seq into active+running lists and call _process_sequence_list."""
+        entity._active_sequences[notify_id] = seq
+        # Pre-populate running so sequence.run() is not called during the test.
+        entity._running_sequences[notify_id] = seq
+        entity._wrapped_light_turn_on = AsyncMock(return_value=True)
+        await entity._process_sequence_list(log_trigger=log_trigger)
+
+    async def test_displaying_light_on_when_state_on_is_top(self):
+        """'displaying Light On' appears when STATE_ON is the top sequence."""
+        logger = _make_mock_logger()
+        entity, _ = _make_light_entity(log_entity=logger)
+
+        seq = _NotificationSequence(
+            notify_id=STATE_ON,
+            pattern=[ColorInfo(WARM_WHITE_RGB, 255)],
+            priority=DEFAULT_PRIORITY,
+        )
+        await self._run_with_sequence(entity, seq, STATE_ON)
+
+        logger.update_message.assert_called_once()
+        msg = logger.update_message.call_args[0][0]
+        assert "displaying Light On" in msg
+
+    async def test_displaying_off_when_state_off_is_top(self):
+        """'displaying Off' appears when the off sequence drives the color."""
+        logger = _make_mock_logger()
+        entity, _ = _make_light_entity(log_entity=logger)
+
+        await self._run_with_sequence(entity, LIGHT_OFF_SEQUENCE, STATE_OFF)
+
+        logger.update_message.assert_called_once()
+        msg = logger.update_message.call_args[0][0]
+        assert "displaying Off" in msg
+
+    async def test_displaying_includes_friendly_name(self):
+        """Friendly name of the showing notification appears in the log message."""
+        logger = _make_mock_logger()
+        entity, _ = _make_light_entity(log_entity=logger)
+
+        notify_id = "switch.fire_alert"
+        fake_state = MagicMock()
+        fake_state.attributes = {"friendly_name": "Fire Alert"}
+        entity.hass.states.get.return_value = fake_state
+
+        seq = _NotificationSequence(
+            notify_id=notify_id,
+            pattern=[ColorInfo((255, 0, 0), 255)],
+            priority=DEFAULT_PRIORITY + 1,
+        )
+        await self._run_with_sequence(entity, seq, notify_id)
+
+        logger.update_message.assert_called_once()
+        msg = logger.update_message.call_args[0][0]
+        assert "Fire Alert" in msg
+        assert "displaying" in msg
+
+    async def test_displaying_falls_back_to_entity_id(self):
+        """Falls back to entity_id in the message when no friendly name is available."""
+        logger = _make_mock_logger()
+        entity, _ = _make_light_entity(log_entity=logger)
+
+        notify_id = "switch.unnamed_alert"
+        entity.hass.states.get.return_value = None  # no state / no friendly name
+
+        seq = _NotificationSequence(
+            notify_id=notify_id,
+            pattern=[ColorInfo((0, 255, 0), 255)],
+            priority=DEFAULT_PRIORITY + 1,
+        )
+        await self._run_with_sequence(entity, seq, notify_id)
+
+        logger.update_message.assert_called_once()
+        msg = logger.update_message.call_args[0][0]
+        assert notify_id in msg
+
+    async def test_no_log_without_trigger(self):
+        """update_message is NOT called when no log_trigger is passed."""
+        logger = _make_mock_logger()
+        entity, _ = _make_light_entity(log_entity=logger)
+
+        entity._active_sequences[STATE_ON] = LIGHT_ON_SEQUENCE
+        entity._running_sequences[STATE_ON] = LIGHT_ON_SEQUENCE
+        entity._last_set_color = LIGHT_ON_SEQUENCE.color
+
+        entity._wrapped_light_turn_on = AsyncMock(return_value=True)
+        await entity._process_sequence_list()  # no log_trigger
+
+        logger.update_message.assert_not_called()
+
+    async def test_trigger_prefixes_message(self):
+        """The log_trigger string forms the first part of the emitted message."""
+        logger = _make_mock_logger()
+        entity, _ = _make_light_entity(log_entity=logger)
+        entity._reset_running_sequences = AsyncMock()
+
+        entity._active_sequences[STATE_ON] = LIGHT_ON_SEQUENCE
+        entity._running_sequences[STATE_ON] = LIGHT_ON_SEQUENCE
+        entity._wrapped_light_turn_on = AsyncMock(return_value=False)
+
+        trigger = "Fire Alert (pri 500) enabled"
+        await entity._process_sequence_list(log_trigger=trigger)
+
+        logger.update_message.assert_called_once()
+        msg = logger.update_message.call_args[0][0]
+        assert msg.startswith(trigger)
+
+    async def test_no_log_entity_no_error(self):
+        """_process_sequence_list runs without error when log_entity is None."""
+        entity, _ = _make_light_entity(log_entity=None)
+        entity._wrapped_light_turn_on = AsyncMock(return_value=True)
+
+        entity._active_sequences[STATE_ON] = LIGHT_ON_SEQUENCE
+        entity._running_sequences[STATE_ON] = LIGHT_ON_SEQUENCE
+
+        await entity._process_sequence_list(log_trigger=_TEST_TRIGGER)  # must not raise
+
+    async def test_displaying_lists_all_same_priority_notifications(self):
+        """All same-priority notifications appear in the 'displaying' part of the message."""
+        logger = _make_mock_logger()
+        entity, _ = _make_light_entity(log_entity=logger)
+
+        _names = {"switch.alert_a": "Alert A", "switch.alert_b": "Alert B"}
+        entity.hass.states.get.side_effect = lambda eid: MagicMock(
+            attributes={"friendly_name": _names.get(eid, eid)}
+        )
+
+        seq_a = _NotificationSequence(
+            notify_id="switch.alert_a",
+            pattern=[ColorInfo((255, 0, 0), 255)],
+            priority=DEFAULT_PRIORITY,
+        )
+        seq_b = _NotificationSequence(
+            notify_id="switch.alert_b",
+            pattern=[ColorInfo((0, 255, 0), 255)],
+            priority=DEFAULT_PRIORITY,
+        )
+        entity._active_sequences["switch.alert_a"] = seq_a
+        entity._active_sequences["switch.alert_b"] = seq_b
+        entity._running_sequences["switch.alert_a"] = seq_a
+        entity._running_sequences["switch.alert_b"] = seq_b
+        entity._wrapped_light_turn_on = AsyncMock(return_value=True)
+        await entity._process_sequence_list(log_trigger=_TEST_TRIGGER)
+
+        logger.update_message.assert_called_once()
+        msg = logger.update_message.call_args[0][0]
+        assert "Alert A" in msg
+        assert "Alert B" in msg
+        assert "displaying" in msg
+
+    async def test_displaying_includes_priority_for_regular_notifications(self):
+        """Priority appears in the 'displaying' description for non-peeking notifications."""
+        logger = _make_mock_logger()
+        entity, _ = _make_light_entity(log_entity=logger)
+
+        notify_id = "switch.fire_alert"
+        entity.hass.states.get.return_value = None
+
+        seq = _NotificationSequence(
+            notify_id=notify_id,
+            pattern=[ColorInfo((255, 0, 0), 255)],
+            priority=500,
+        )
+        await self._run_with_sequence(entity, seq, notify_id)
+
+        msg = logger.update_message.call_args[0][0]
+        assert "pri 500" in msg
+
+    async def test_peeking_label_shown_when_boost_causes_win(self):
+        """'(peeking)' appears when the notification wins only because of the priority boost."""
+        from custom_components.color_notify.const import MAXIMUM_PRIORITY
+
+        logger = _make_mock_logger()
+        entity, _ = _make_light_entity(log_entity=logger)
+
+        entity.hass.states.get.return_value = None  # entity_id used as name
+
+        # A high-priority notification already showing (not boosted).
+        seq_high = _NotificationSequence(
+            notify_id="switch.high_prio",
+            pattern=[ColorInfo((255, 0, 0), 255)],
+            priority=10,
+        )
+        entity._active_sequences["switch.high_prio"] = seq_high
+
+        # A low-priority notification that was just added with a peek boost.
+        seq_low = _NotificationSequence(
+            notify_id="switch.low_prio",
+            pattern=[ColorInfo((0, 255, 0), 255)],
+            priority=3 + MAXIMUM_PRIORITY,  # boosted; un-boosted would be 3
+        )
+        entity._active_sequences["switch.low_prio"] = seq_low
+        entity._running_sequences["switch.low_prio"] = seq_low
+        entity._wrapped_light_turn_on = AsyncMock(return_value=True)
+        await entity._process_sequence_list(log_trigger=_TEST_TRIGGER)
+
+        msg = logger.update_message.call_args[0][0]
+        assert "(peeking)" in msg
+
+    async def test_no_peek_boost_when_already_highest_priority(self):
+        """A notification that beats current top priority is not boosted by _work_loop."""
+        from custom_components.color_notify.const import MAXIMUM_PRIORITY
+
+        # The boost condition in _work_loop is:
+        #   item.sequence.priority < current_top_priority
+        # When only STATE_OFF is active, current_top is 0. A notification with
+        # priority 10 is already the natural top (10 > 0), so the condition is
+        # False and priority must remain unchanged at its natural value.
+        assert LIGHT_OFF_SEQUENCE.priority == 0, "STATE_OFF sentinel priority"
+        natural_priority = 10
+        assert natural_priority > LIGHT_OFF_SEQUENCE.priority, "notification is already top"
+        assert natural_priority <= MAXIMUM_PRIORITY, "would not be boosted"
+
+
+# ---------------------------------------------------------------------------
+# NotificationLightEntity + event log — _handle_notification_change
+# ---------------------------------------------------------------------------
+
+
+class TestHandleStateChangeEventLog:
+    """log_trigger values queued by _handle_notification_change."""
+
+    @staticmethod
+    def _make_event(notify_id, state_value, attributes=None):
+        event = MagicMock()
+        new_state = MagicMock()
+        new_state.state = state_value
+        new_state.attributes = attributes or {}
+        event.data = {"entity_id": notify_id, "new_state": new_state}
+        return event
+
+    async def test_notification_added_trigger_includes_friendly_name(self):
+        """Enabling a notification places a trigger with the friendly name in the queue."""
+        entity, _ = _make_light_entity()
+
+        notify_id = "switch.fire_alert"
+        seq_mock = MagicMock()
+        seq_mock.priority = DEFAULT_PRIORITY
+        entity._create_sequence_from_attr = MagicMock(return_value=seq_mock)
+
+        await entity._handle_notification_change(
+            self._make_event(notify_id, STATE_ON, {"friendly_name": "Fire Alert"})
+        )
+
+        item = entity._task_queue.get_nowait()
+        assert item.log_trigger is not None
+        assert "Fire Alert" in item.log_trigger
+        assert "enabled" in item.log_trigger
+
+    async def test_notification_added_trigger_includes_priority(self):
+        """The queue trigger for an add includes the notification's natural priority."""
+        entity, _ = _make_light_entity()
+
+        notify_id = "switch.fire_alert"
+        seq_mock = MagicMock()
+        seq_mock.priority = 500
+        entity._create_sequence_from_attr = MagicMock(return_value=seq_mock)
+
+        await entity._handle_notification_change(
+            self._make_event(notify_id, STATE_ON, {"friendly_name": "Fire Alert"})
+        )
+
+        item = entity._task_queue.get_nowait()
+        assert f"pri 500" in item.log_trigger
+
+    async def test_notification_removed_trigger_includes_friendly_name(self):
+        """Disabling a notification places a trigger with the friendly name in the queue."""
+        entity, _ = _make_light_entity()
+
+        notify_id = "switch.fire_alert"
+
+        await entity._handle_notification_change(
+            self._make_event(notify_id, STATE_OFF, {"friendly_name": "Fire Alert"})
+        )
+
+        item = entity._task_queue.get_nowait()
+        assert item.log_trigger is not None
+        assert "Fire Alert" in item.log_trigger
+        assert "disabled" in item.log_trigger
+
+    async def test_notification_removed_trigger_uses_natural_priority(self):
+        """Disabled trigger uses the natural (un-boosted) priority even when sequence is peeking."""
+        from custom_components.color_notify.const import MAXIMUM_PRIORITY
+
+        entity, _ = _make_light_entity()
+        notify_id = "switch.fire_alert"
+
+        # Simulate a sequence that is currently in the active list with a peek boost.
+        seq = _NotificationSequence(
+            notify_id=notify_id,
+            pattern=[ColorInfo((255, 0, 0), 255)],
+            priority=100 + MAXIMUM_PRIORITY,  # boosted; natural = 100
+        )
+        entity._active_sequences[notify_id] = seq
+
+        await entity._handle_notification_change(
+            self._make_event(notify_id, STATE_OFF, {"friendly_name": "Fire Alert"})
+        )
+
+        item = entity._task_queue.get_nowait()
+        assert "pri 100" in item.log_trigger
+
+    async def test_notification_added_falls_back_to_entity_id(self):
+        """entity_id is used in the trigger when there is no friendly name."""
+        entity, _ = _make_light_entity()
+
+        notify_id = "switch.unnamed"
+        seq_mock = MagicMock()
+        seq_mock.priority = DEFAULT_PRIORITY
+        entity._create_sequence_from_attr = MagicMock(return_value=seq_mock)
+
+        await entity._handle_notification_change(self._make_event(notify_id, STATE_ON))
+
+        item = entity._task_queue.get_nowait()
+        assert notify_id in item.log_trigger
+
+    async def test_notification_removed_falls_back_to_entity_id(self):
+        """entity_id is used in the trigger when there is no friendly name."""
+        entity, _ = _make_light_entity()
+
+        notify_id = "switch.unnamed"
+
+        await entity._handle_notification_change(self._make_event(notify_id, STATE_OFF))
+
+        item = entity._task_queue.get_nowait()
+        assert notify_id in item.log_trigger
+
+    async def test_no_log_entity_no_error_on_add(self):
+        """_handle_notification_change runs without error when log_entity is None (add)."""
+        entity, _ = _make_light_entity(log_entity=None)
+        seq_mock = MagicMock()
+        seq_mock.priority = DEFAULT_PRIORITY
+        entity._create_sequence_from_attr = MagicMock(return_value=seq_mock)
+
+        await entity._handle_notification_change(
+            self._make_event("switch.x", STATE_ON)
+        )  # must not raise
+
+    async def test_no_log_entity_no_error_on_remove(self):
+        """_handle_notification_change runs without error when log_entity is None (remove)."""
+        entity, _ = _make_light_entity(log_entity=None)
+
+        await entity._handle_notification_change(
+            self._make_event("switch.x", STATE_OFF)
+        )  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# async_turn_on / async_turn_off log triggers
+# ---------------------------------------------------------------------------
+
+
+class TestTurnOnOffEventLog:
+    """Log triggers queued by async_turn_on and async_turn_off."""
+
+    async def test_turn_on_queues_light_turned_on_trigger(self):
+        """async_turn_on places a 'Light turned on' trigger in the queue."""
+        entity, _ = _make_light_entity()
+        del entity.async_turn_on  # restore real method (helper mocks it as AsyncMock)
+        # Seed the off sentinel so _get_top_sequences()[0] doesn't IndexError.
+        entity._active_sequences[STATE_OFF] = LIGHT_OFF_SEQUENCE
+
+        await entity.async_turn_on()
+
+        item = entity._task_queue.get_nowait()
+        assert item.log_trigger == "Light turned on"
+
+    async def test_turn_off_queues_light_turned_off_trigger(self):
+        """async_turn_off places a 'Light turned off' trigger in the queue."""
+        entity, _ = _make_light_entity()
+        del entity.async_turn_off  # restore real method (helper mocks it as AsyncMock)
+
+        await entity.async_turn_off()
+
+        item = entity._task_queue.get_nowait()
+        assert item.log_trigger == "Light turned off"

--- a/tests/test_light.py
+++ b/tests/test_light.py
@@ -4,6 +4,8 @@ import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from custom_components.color_notify.light import (
+    ATTR_BRIGHTNESS,
+    ATTR_COLOR_MODE,
     ColorInfo,
     LIGHT_OFF_SEQUENCE,
     LIGHT_ON_SEQUENCE,
@@ -209,3 +211,35 @@ class TestTurnOnColorBrightness:
 
         assert len(captured) == 1
         assert captured[0].color.rgb == (127, 0, 0)
+
+
+class TestStateAttributesWhenOff:
+    """state_attributes must explicitly clear color attributes when the light is off.
+
+    HA's entity framework only merges state_attributes when the dict is truthy.
+    An empty dict {} is falsy and is skipped, so the HA state machine retains only
+    capability attributes and the frontend has no brightness key to inspect.
+    Without an explicit brightness=None, the frontend keeps the last displayed
+    brightness value and shows a colored icon + X instead of a grey dimmed icon.
+    """
+
+    def test_state_attributes_includes_brightness_as_none_when_off(self) -> None:
+        """state_attributes must contain brightness=None when the light is off."""
+        entity, _ = make_entity(is_on=False)
+        entity._last_on_rgb = (255, 249, 216)  # simulate a prior on-state
+        attrs = entity.state_attributes
+        assert ATTR_BRIGHTNESS in attrs, (
+            "ATTR_BRIGHTNESS must be present (as None) when off so HA merges it "
+            "and the frontend shows a grey icon instead of a bright colored icon"
+        )
+        assert attrs[ATTR_BRIGHTNESS] is None
+
+    def test_state_attributes_includes_color_mode_as_none_when_off(self) -> None:
+        """state_attributes must contain color_mode=None when the light is off."""
+        entity, _ = make_entity(is_on=False)
+        attrs = entity.state_attributes
+        assert ATTR_COLOR_MODE in attrs, (
+            "ATTR_COLOR_MODE must be present (as None) when off so the frontend "
+            "knows this is a color-capable light in the off state"
+        )
+        assert attrs[ATTR_COLOR_MODE] is None

--- a/tests/test_light.py
+++ b/tests/test_light.py
@@ -15,8 +15,9 @@ from custom_components.color_notify.const import DEFAULT_PRIORITY
 
 
 class FakeState:
-    def __init__(self, state: str):
+    def __init__(self, state: str, attributes: dict | None = None):
         self.state = state
+        self.attributes = attributes or {}
 
 
 def make_entity(is_on=False):
@@ -46,6 +47,7 @@ def make_entity(is_on=False):
         unique_id="test_id",
         wrapped_entity_id="light.test",
         config_entry=entry,
+        log_entity=None,
     )
     entity.hass = MagicMock()
 
@@ -70,11 +72,12 @@ class TestWorkerSpawnOrder:
             call_order.append("get_last_state")
             return FakeState("on")
 
-        def tracked_create_background_task(*args, **kwargs):
+        def tracked_create_background_task(hass, coro, name, **kwargs):
             call_order.append("create_background_task")
-            for arg in args:
-                if asyncio.iscoroutine(arg):
-                    arg.close()
+            coro.close()
+            task = MagicMock()
+            task.cancel = MagicMock()
+            return task
 
         entity.async_get_last_state = tracked_get_last_state
         entry.async_create_background_task = tracked_create_background_task
@@ -85,14 +88,26 @@ class TestWorkerSpawnOrder:
             "get_last_state"
         )
 
+        await entity.async_will_remove_from_hass()
+
     async def test_worker_spawns_without_restored_state(self):
         """Background task is created even when there's no restored state."""
         entity, entry = make_entity()
         entity.async_get_last_state = AsyncMock(return_value=None)
 
+        def create_task_mock(hass, coro, name, **kwargs):
+            coro.close()
+            task = MagicMock()
+            task.cancel = MagicMock()
+            return task
+
+        entry.async_create_background_task = MagicMock(side_effect=create_task_mock)
+
         await entity.async_added_to_hass()
 
         entry.async_create_background_task.assert_called_once()
+
+        await entity.async_will_remove_from_hass()
 
 
 class TestAsyncToggleDynamicPriority:
@@ -161,7 +176,7 @@ class TestTurnOnColorBrightness:
         entity, _entry = self._make_entity()
         captured: list[_NotificationSequence] = []
 
-        async def capture_add(notify_id: str, sequence: _NotificationSequence) -> None:
+        async def capture_add(notify_id: str, sequence: _NotificationSequence, log_trigger: str | None = None) -> None:
             captured.append(sequence)
 
         entity._add_sequence = capture_add
@@ -181,7 +196,7 @@ class TestTurnOnColorBrightness:
         entity._last_on_rgb = (255, 0, 0)
         captured: list[_NotificationSequence] = []
 
-        async def capture_add(notify_id: str, sequence: _NotificationSequence) -> None:
+        async def capture_add(notify_id: str, sequence: _NotificationSequence, log_trigger: str | None = None) -> None:
             captured.append(sequence)
 
         entity._add_sequence = capture_add

--- a/tests/test_light.py
+++ b/tests/test_light.py
@@ -1,7 +1,8 @@
 """Tests for color_notify light entity behavior."""
 
-import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
+
+from conftest import make_config_entry
 
 from custom_components.color_notify.light import (
     ATTR_BRIGHTNESS,
@@ -23,27 +24,7 @@ class FakeState:
 
 
 def make_entity(is_on=False):
-    entry = MagicMock()
-    entry.data = {
-        "type": "light",
-        "name": "Test Light",
-        "entity_id": "light.test",
-        "color_picker": [255, 249, 216],
-        "dynamic_priority": True,
-        "priority": DEFAULT_PRIORITY,
-        "delay": True,
-        "delay_time": {"seconds": 5},
-        "peek_time": {"seconds": 5},
-    }
-    entry.options = {}
-    entry.title = "[Light] Test Light"
-    def _close_coros(*args, **kwargs):
-        for arg in args:
-            if asyncio.iscoroutine(arg):
-                arg.close()
-
-    entry.async_create_background_task = MagicMock(side_effect=_close_coros)
-    entry.async_on_unload = MagicMock()
+    entry = make_config_entry()
 
     entity = NotificationLightEntity(
         unique_id="test_id",


### PR DESCRIPTION
A recent commit to fix brightness caused the light icon to appear 'bright but off' when the light was off. This fixes the dimming of the UI icon.

This adds an optional per-light event log, tracking what is displayed on each light. This is helpful for a "why did a notification go off and what did it mean" when you start to have too many notifications 😆